### PR TITLE
Fix: photo data parsing to access 'data' property from JSON manifest

### DIFF
--- a/plugins/vite/feed-sitemap.ts
+++ b/plugins/vite/feed-sitemap.ts
@@ -39,8 +39,8 @@ export function createFeedSitemapPlugin(siteConfig: SiteConfig): Plugin {
           __dirname,
           '../../packages/data/src/photos-manifest.json',
         )
-        const photosData: PhotoData[] = JSON.parse(
-          readFileSync(manifestPath, 'utf-8'),
+        const photosData: PhotoData[] = (JSON.parse(
+          readFileSync(manifestPath, 'utf-8'),).data
         )
 
         // Sort photos by date taken (newest first)

--- a/scripts/photo-loader.ts
+++ b/scripts/photo-loader.ts
@@ -30,7 +30,7 @@ class BuildTimePhotoLoader {
     try {
       const manifestPath = join(workdir, 'src/data/photos-manifest.json')
       const manifestContent = readFileSync(manifestPath, 'utf-8')
-      this.photos = JSON.parse(manifestContent) as PhotoManifest[]
+      this.photos = JSON.parse(manifestContent).data as PhotoManifest[]
 
       this.photos.forEach((photo) => {
         this.photoMap[photo.id] = photo


### PR DESCRIPTION
Update the photo data parsing logic to correctly access the 'data' property from the JSON manifest, ensuring proper handling of photo information.