### PR TITLE
fix: Make the social field truly optional and remove default social accounts

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -42,11 +42,7 @@ const defaultConfig: SiteConfig = {
     name: 'Innei',
     url: 'https://innei.in/',
     avatar: 'https://cdn.jsdelivr.net/gh/Innei/static@master/avatar.png',
-  },
-  social: {
-    twitter: '@__oQuery',
-    github: 'Innei',
-  },
+  }
 }
 export const siteConfig: SiteConfig = merge(defaultConfig, userConfig) as any
 


### PR DESCRIPTION
According to the configuration in `config.json` from the README, the `github` field does not exist. However, during actual deployment, it will still be merged and use the default `github` field. Additionally, even if the `social` field is deleted, the default `twitter` and `github` fields will still exist, meaning they are not truly optional:
```json
{
  "name": "My Afilmory",
  "title": "My Afilmory",
  "description": "Capturing beautiful moments in life",
  "url": "https://afilmory.example.com",
  "accentColor": "#007bff", // Optional, set theme color
  "author": {
    "name": "Your Name", // Required, set author name
    "url": "https://example.com", // Optional, set author homepage
    "avatar": "https://example.com/avatar.png" // Optional, set author avatar
  },
  "social": {
    "twitter": "@yourusername" // Optional, set social accounts
  }
}
```

The specific reason is that the `defaultConfig` in the code configured optional fields and performed a merge:
```ts
const defaultConfig: SiteConfig = {
  name: "Innei's Afilmory",
  title: "Innei's Afilmory",
  description:
    'Capturing beautiful moments in life, documenting daily warmth and emotions through my lens.',
  url: 'https://afilmory.innei.in',
  accentColor: '#007bff',
  author: {
    name: 'Innei',
    url: 'https://innei.in/',
    avatar: 'https://cdn.jsdelivr.net/gh/Innei/static@master/avatar.png',
  },
  social: {
    twitter: '@__oQuery',
    github: 'Innei',
  },
}
```

 ```ts
 import { merge } from 'es-toolkit/compat'
 ...
 export const siteConfig = merge(defaultConfig, userConfig) as any
 ```  

**Code Adjustment (site.config.ts)**:
The social field has been removed from `defaultConfig`. 
