### PR TITLE
fix: Zoom and ContextMenu not working

### DIFF
--- a/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
@@ -129,6 +129,7 @@ export const ProgressiveImage = ({
       {/* 高分辨率图片 - 只在成功加载且非错误状态时显示 */}
       {highResLoaded && blobSrc && isCurrentImage && !error && (
         <div
+          className="absolute inset-0 h-full w-full"
           onContextMenu={(e) => {
             const items = createContextMenuItems(blobSrc, alt, t)
             showContextMenu(items, e)


### PR DESCRIPTION
Fix #51, Zoom and ContextMenu not working because of a zero-height `<div>` node.