### PR TITLE
feat: add minimap support

### DIFF
--- a/apps/web/src/components/ui/map/GenericMap.tsx
+++ b/apps/web/src/components/ui/map/GenericMap.tsx
@@ -7,6 +7,8 @@ import type { BaseMapProps, PhotoMarker } from '~/types/map'
 interface GenericMapProps extends Omit<BaseMapProps, 'handlers'> {
   /** Photo markers to display */
   markers?: PhotoMarker[]
+  /** ID of the marker to select */
+  selectedMarkerId?: string | null
   /** Callback when marker is clicked */
   onMarkerClick?: (marker: PhotoMarker) => void
   /** Callback when GeoJSON feature is clicked */
@@ -24,6 +26,7 @@ const DEFAULT_MARKERS: PhotoMarker[] = []
  */
 export const GenericMap: React.FC<GenericMapProps> = ({
   markers = DEFAULT_MARKERS,
+  selectedMarkerId,
   onMarkerClick,
   onGeoJsonClick,
   onGeolocate,
@@ -61,6 +64,7 @@ export const GenericMap: React.FC<GenericMapProps> = ({
     <MapComponent
       {...props}
       markers={markers}
+      selectedMarkerId={selectedMarkerId}
       initialViewState={calculatedInitialViewState}
       autoFitBounds={autoFitBounds}
       handlers={handlers}

--- a/apps/web/src/components/ui/map/MapLibre.tsx
+++ b/apps/web/src/components/ui/map/MapLibre.tsx
@@ -4,10 +4,10 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Map from 'react-map-gl/maplibre'
 
+import { getMapStyle } from '~/lib/map/style'
 import { calculateMapBounds } from '~/lib/map-utils'
 import type { PhotoMarker } from '~/types/map'
 
-import MAP_STYLE from './MapLibreStyle.json'
 import {
   ClusterMarker,
   clusterMarkers,
@@ -27,6 +27,7 @@ export interface PureMaplibreProps {
     zoom: number
   }
   markers?: PhotoMarker[]
+  selectedMarkerId?: string | null
   geoJsonData?: GeoJSON.FeatureCollection
   onMarkerClick?: (marker: PhotoMarker) => void
   onGeoJsonClick?: (event: any) => void
@@ -42,6 +43,7 @@ export const Maplibre = ({
   id,
   initialViewState = DEFAULT_VIEW_STATE,
   markers = DEFAULT_MARKERS,
+  selectedMarkerId: externalSelectedMarkerId,
   geoJsonData,
   onMarkerClick,
   onGeoJsonClick,
@@ -52,10 +54,19 @@ export const Maplibre = ({
   mapRef,
   autoFitBounds = true,
 }: PureMaplibreProps) => {
-  const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(null)
+  const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(
+    externalSelectedMarkerId || null,
+  )
   const [currentZoom, setCurrentZoom] = useState(initialViewState.zoom)
   const [viewState, setViewState] = useState(initialViewState)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
+
+  // Sync external selectedMarkerId with internal state
+  useEffect(() => {
+    if (externalSelectedMarkerId !== undefined) {
+      setSelectedMarkerId(externalSelectedMarkerId)
+    }
+  }, [externalSelectedMarkerId])
 
   // Handle marker click
   const handleMarkerClick = useCallback(
@@ -194,8 +205,7 @@ export const Maplibre = ({
         ref={mapRef}
         {...viewState}
         style={{ width: '100%', height: '100%' }}
-        // @ts-expect-error
-        mapStyle={MAP_STYLE}
+        mapStyle={getMapStyle()}
         attributionControl={false}
         interactiveLayerIds={geoJsonData ? ['data'] : undefined}
         onClick={onGeoJsonClick}

--- a/apps/web/src/components/ui/photo-viewer/MiniMap.tsx
+++ b/apps/web/src/components/ui/photo-viewer/MiniMap.tsx
@@ -1,0 +1,69 @@
+import 'maplibre-gl/dist/maplibre-gl.css'
+
+import { useCallback, useState } from 'react'
+import { Link } from 'react-router'
+import Map from 'react-map-gl/maplibre'
+
+import { getMapStyle } from '~/lib/map/style'
+
+
+interface MiniMapProps {
+  latitude: number
+  longitude: number
+  photoId: string
+}
+
+export const MiniMap = ({ latitude, longitude, photoId }: MiniMapProps) => {
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  const handleMapLoad = useCallback(() => {
+    setIsLoaded(true)
+  }, [])
+
+  // 检查是否有有效的GPS坐标
+  const hasValidCoordinates = latitude !== 0 && longitude !== 0
+
+  if (!hasValidCoordinates) {
+    return null
+  }
+
+  return (
+    <div className="relative h-40 w-full overflow-hidden rounded-lg border border-white/10">
+      <Map
+        mapLib={import('maplibre-gl')}
+        key={`${latitude}-${longitude}`}
+        longitude={longitude}
+        latitude={latitude}
+        zoom={15}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle={getMapStyle()}
+        attributionControl={false}
+        onLoad={handleMapLoad}
+        interactive={false}
+      />
+
+      {/* 中心标记 */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+        <div className="relative">
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 h-3 w-3 animate-ping rounded-full bg-blue-400 opacity-75" />
+          <div className="relative h-2 w-2 rounded-full bg-blue-500 ring-2 ring-white/80" />
+        </div>
+      </div>
+
+      {/* 加载状态 */}
+      {!isLoaded && (
+        <div className="bg-material-ultra-thin absolute inset-0 flex items-center justify-center backdrop-blur-sm">
+          <div className="text-xs text-white/60">加载地图中...</div>
+        </div>
+      )}
+
+      {/* 点击跳转到explore页面的遮罩 */}
+      <Link
+        to={`/explory?photoId=${photoId}`}
+        target='_blank'
+        className="absolute inset-0 cursor-pointer transition-opacity duration-200 hover:bg-black/10"
+        aria-label="在地图中查看位置"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/lib/map/style.ts
+++ b/apps/web/src/lib/map/style.ts
@@ -1,0 +1,12 @@
+import { siteConfig } from '@config'
+import type { StyleSpecification } from 'maplibre-gl'
+
+import BUILTIN_MAP_STYLE from '../../components/ui/map/MapLibreStyle.json'
+
+export const getMapStyle = (): string | StyleSpecification => {
+  const builtinStyle = BUILTIN_MAP_STYLE as StyleSpecification
+  if (!siteConfig.mapStyle) {
+    return builtinStyle
+  }
+  return siteConfig.mapStyle === 'builtin' ? builtinStyle : siteConfig.mapStyle
+}

--- a/apps/web/src/modules/map/MapLibreAdapter.tsx
+++ b/apps/web/src/modules/map/MapLibreAdapter.tsx
@@ -37,6 +37,7 @@ export const MapLibreMapComponent: React.FC<BaseMapProps> = ({
   id,
   initialViewState,
   markers,
+  selectedMarkerId,
   geoJsonData,
   className,
   style,
@@ -100,6 +101,7 @@ export const MapLibreMapComponent: React.FC<BaseMapProps> = ({
       id={id}
       initialViewState={initialViewState}
       markers={markers}
+      selectedMarkerId={selectedMarkerId}
       geoJsonData={geoJsonData}
       onMarkerClick={handleMarkerClick}
       onGeoJsonClick={handleGeoJsonClick}

--- a/apps/web/src/types/map/provider.ts
+++ b/apps/web/src/types/map/provider.ts
@@ -33,6 +33,7 @@ export interface BaseMapProps {
   id?: string
   initialViewState?: MapViewState
   markers?: PhotoMarker[]
+  selectedMarkerId?: string | null
   geoJsonData?: GeoJSON.FeatureCollection
   className?: string
   style?: React.CSSProperties

--- a/config.example.json
+++ b/config.example.json
@@ -11,5 +11,6 @@
   },
   "map": [
     "maplibre"
-  ]
+  ],
+  "mapStyle": "builtin"
 }

--- a/site.config.ts
+++ b/site.config.ts
@@ -12,6 +12,7 @@ export interface SiteConfig {
   social?: Social
   feed?: Feed
   map?: MapConfig
+  mapStyle?: string
 }
 
 /**


### PR DESCRIPTION
fix #48 

1. 支持在侧边栏显示小地图 
<img width="526" height="561" alt="image" src="https://github.com/user-attachments/assets/32b76094-ee38-4cee-b669-c351e27eac44" />

2. 点击小地图会跳转到 explore 页面中，并且 focus 原照片 
<img width="1724" height="2019" alt="image" src="https://github.com/user-attachments/assets/9da00c47-c4d3-464c-91c4-43ed79d81c83" />

3. 支持在 config 中自定义 map style。默认使用 builtin style，用户可以传入其他 url。
<img width="482" height="635" alt="image" src="https://github.com/user-attachments/assets/87d7677b-1b20-4bde-8373-e98b894ed44f" />

TODO：

- [x] clean up 一下 claude code 写的代码