### PR TITLE
feat(map): sync selected status with url

### DIFF
--- a/apps/web/src/components/ui/map/MapLibre.tsx
+++ b/apps/web/src/components/ui/map/MapLibre.tsx
@@ -43,7 +43,7 @@ export const Maplibre = ({
   id,
   initialViewState = DEFAULT_VIEW_STATE,
   markers = DEFAULT_MARKERS,
-  selectedMarkerId: externalSelectedMarkerId,
+  selectedMarkerId,
   geoJsonData,
   onMarkerClick,
   onGeoJsonClick,
@@ -54,34 +54,31 @@ export const Maplibre = ({
   mapRef,
   autoFitBounds = true,
 }: PureMaplibreProps) => {
-  const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(
-    externalSelectedMarkerId || null,
-  )
   const [currentZoom, setCurrentZoom] = useState(initialViewState.zoom)
   const [viewState, setViewState] = useState(initialViewState)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
+  const [hasInitialFitCompleted, setHasInitialFitCompleted] = useState(false)
 
-  // Sync external selectedMarkerId with internal state
-  useEffect(() => {
-    if (externalSelectedMarkerId !== undefined) {
-      setSelectedMarkerId(externalSelectedMarkerId)
-    }
-  }, [externalSelectedMarkerId])
-
-  // Handle marker click
+  // Handle marker click - only call the external callback
   const handleMarkerClick = useCallback(
     (marker: PhotoMarker) => {
-      // Toggle selection: if already selected, deselect; otherwise select
-      setSelectedMarkerId((prev) => (prev === marker.id ? null : marker.id))
       onMarkerClick?.(marker)
     },
     [onMarkerClick],
   )
 
-  // Handle marker close
+  // Handle marker close - call onMarkerClick with the currently selected marker to toggle it off
   const handleMarkerClose = useCallback(() => {
-    setSelectedMarkerId(null)
-  }, [])
+    if (selectedMarkerId && onMarkerClick) {
+      // Find the currently selected marker and call onMarkerClick to deselect it
+      const selectedMarker = markers.find(
+        (marker) => marker.id === selectedMarkerId,
+      )
+      if (selectedMarker) {
+        onMarkerClick(selectedMarker)
+      }
+    }
+  }, [selectedMarkerId, onMarkerClick, markers])
 
   // Clustered markers
   const clusteredMarkers = useMemo(
@@ -101,12 +98,21 @@ export const Maplibre = ({
     return 2 // 跨洲
   }, [])
 
-  // 自动适配到包含所有照片的区域
+  // 自动适配到包含所有照片的区域 - 只在初次加载时执行
   const fitMapToBounds = useCallback(() => {
-    if (!autoFitBounds || markers.length === 0 || !isMapLoaded) return
+    if (
+      !autoFitBounds ||
+      markers.length === 0 ||
+      !isMapLoaded ||
+      hasInitialFitCompleted
+    )
+      return
 
     const bounds = calculateMapBounds(markers)
     if (!bounds) return
+
+    // 标记初次适配已完成
+    setHasInitialFitCompleted(true)
 
     // 如果只有一个点，设置默认缩放级别
     if (markers.length === 1) {
@@ -181,7 +187,14 @@ export const Maplibre = ({
       setViewState(newViewState)
       setCurrentZoom(zoom)
     }
-  }, [markers, autoFitBounds, isMapLoaded, mapRef, calculateZoomLevel])
+  }, [
+    markers,
+    autoFitBounds,
+    isMapLoaded,
+    mapRef,
+    calculateZoomLevel,
+    hasInitialFitCompleted,
+  ])
 
   // 当地图加载完成时触发适配
   const handleMapLoad = useCallback(() => {


### PR DESCRIPTION
先前 `?photoId=[photo ID]` 仅在地图模块加载时候判断一次，后续无论是更新选中抑或是取消选中都不会更新。

此 PR 实现 marker 选中状态与 URL parameters 的双向同步，持续自动更新 `?photoId=[photo ID]`。