### PR TITLE
fix: photo id conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ This will automatically pull resources from the remote repository, avoiding rebu
 #### Build Options (`options`)
 
 - `defaultConcurrency`: Default concurrency
+- `digestSuffixLength`: The length of the SHA-256 digest appended to the photo ID.
 - `enableLivePhotoDetection`: Enable Live Photo detection
 - `showProgress`: Show build progress
 - `showDetailedStats`: Show detailed statistics

--- a/builder.config.ts
+++ b/builder.config.ts
@@ -36,6 +36,9 @@ export interface BuilderConfig {
 
     // 是否在构建完成后显示详细统计
     showDetailedStats: boolean
+
+    // 摘要后缀长度（0表示不添加后缀，>0表示添加sha256摘要的前N个字符作为后缀）
+    digestSuffixLength?: number
   }
 
   // 日志配置
@@ -97,6 +100,7 @@ export const defaultBuilderConfig: BuilderConfig = {
     enableLivePhotoDetection: true,
     showProgress: true,
     showDetailedStats: true,
+    digestSuffixLength: 0,
   },
 
   logging: {

--- a/packages/builder/src/cli.ts
+++ b/packages/builder/src/cli.ts
@@ -286,6 +286,9 @@ async function main() {
     logger.main.info(
       `   Live Photo 检测：${config.options.enableLivePhotoDetection ? '启用' : '禁用'}`,
     )
+    logger.main.info(
+      `   照片后缀摘要长度：${config.options.digestSuffixLength}`,
+    )
     logger.main.info(`   Worker 数：${config.performance.worker.workerCount}`)
     logger.main.info(`   Worker 超时：${config.performance.worker.timeout}ms`)
     logger.main.info(

--- a/packages/builder/src/photo/processor.ts
+++ b/packages/builder/src/photo/processor.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 
 import type { _Object } from '@aws-sdk/client-s3'
 
@@ -33,7 +32,6 @@ export async function processPhoto(
     return { item: null, type: 'failed' }
   }
 
-  const photoId = path.basename(key, path.extname(key))
   const existingItem = existingManifestMap.get(key)
 
   // 创建并设置全局 logger
@@ -45,7 +43,6 @@ export async function processPhoto(
   // 构建处理上下文
   const context: PhotoProcessingContext = {
     photoKey: key,
-    photoId,
     obj,
     existingItem,
     livePhotoMap,


### PR DESCRIPTION
- Add config `options.digestSuffixLength` to append SHA-256 digest to the photo IDs.

This fixes #63.

当 `options.digestSuffixLength` 被设置为非0值的时候, 会计算 `s3Key` 的sha256，并且append前 `options.digestSuffixLength` 个字符到photo id。

After:
```
➜  afilmory git:(fix-photo-id-conflict) grep digestSuffixLength *json                                                   
builder.config.json:    "digestSuffixLength": 8
➜  afilmory git:(fix-photo-id-conflict) grep DSC_2388 apps/web/src/data/photos-manifest.json | grep -E 'id|s3Key'
      "id": "DSC_2388-已增强-降噪_e864ff7b",
      "s3Key": "20250412_birds/birds/灰喜鹊/DSC_2388-已增强-降噪.jpg",
      "id": "DSC_2388-已增强-降噪_b56b6014",
      "s3Key": "20250401_japan/福冈/DSC_2388-已增强-降噪.jpg",
```