### PR TITLE
fix(exif): use original HEIC buffer for EXIF extraction

### DIFF
--- a/packages/builder/src/image/exif.ts
+++ b/packages/builder/src/image/exif.ts
@@ -44,7 +44,7 @@ export async function extractExifData(
       `${crypto.randomUUID()}.jpg`,
     )
 
-    await writeFile(tempImagePath, imageBuffer)
+    await writeFile(tempImagePath, originalBuffer || imageBuffer)
     const exifData = await exiftool.read(tempImagePath)
     const result = handleExifData(exifData, metadata)
 


### PR DESCRIPTION
## Summary
- Use original HEIC buffer instead of heicConvert processed data for EXIF extraction
- Fix missing EXIF data issue with HEIC files

## Problem
When processing HEIC files, we use `heicConvert` to convert them to JPEG format. However, some EXIF data gets lost during this conversion process.

## Solution
```typescript
// Before
await writeFile(tempImagePath, imageBuffer)

// After  
await writeFile(tempImagePath, originalBuffer || imageBuffer)
```

For HEIC files, use the original buffer for EXIF extraction to preserve all metadata. For other formats, continue using the processed buffer.