### PR TITLE
fix(map): GPS coordinate hemisphere inversion bug

### DIFF
--- a/apps/web/src/lib/map-utils.ts
+++ b/apps/web/src/lib/map-utils.ts
@@ -52,12 +52,13 @@ export function convertExifGPSToDecimal(exif: PickedExif | null): {
         ? GPSDirection.West
         : GPSDirection.East
 
-    // Apply reference direction to coordinates
-    if (latitudeRef === GPSDirection.South) {
+    // Apply reference direction to coordinates only if they're positive
+    // Some EXIF tools already provide properly signed coordinates
+    if (latitudeRef === GPSDirection.South && latitude > 0) {
       latitude = -latitude
     }
 
-    if (longitudeRef === GPSDirection.West) {
+    if (longitudeRef === GPSDirection.West && longitude > 0) {
       longitude = -longitude
     }
 


### PR DESCRIPTION
## Problem
Photos taken in the southern hemisphere were incorrectly displayed in the northern hemisphere on the map. This affected all GPS-enabled photos, causing them to appear on the wrong side of the equator/prime meridian.

<img width="1754" height="1010" alt="CleanShot 2025-08-25 at 12 43 55@2x" src="https://github.com/user-attachments/assets/7e4187e8-425c-401b-932b-88fc3443f534" />


## Root Cause
The issue was in the GPS coordinate conversion logic in `apps/web/src/lib/map-utils.ts`. The `convertExifGPSToDecimal` function incorrectly handled EXIF GPS coordinates by unconditionally applying directional references:

```typescript
// Buggy code - always inverted coordinates based on reference
if (latitudeRef === GPSDirection.South) {
  latitude = -latitude  // ❌ Made negative coords positive
}
if (longitudeRef === GPSDirection.West) {
  longitude = -longitude  // ❌ Made negative coords positive  
}
```

The problem occurred because modern EXIF tools can provide GPS coordinates in two formats:
1. **Already signed decimal degrees** - where southern/western coordinates are already negative
2. **Unsigned values with reference fields** - where coordinates are positive with separate N/S/E/W indicators

The original code assumed format 2 and always applied the directional reference, which caused already-negative coordinates (format 1) to become positive, flipping southern hemisphere locations to the northern hemisphere.

## Solution
Modified the coordinate conversion logic to only apply directional references when coordinates are positive, preserving already-signed coordinates:

```typescript
// Fixed code - only apply reference if coordinates are unsigned (positive)
if (latitudeRef === GPSDirection.South && latitude > 0) {
  latitude = -latitude
}
if (longitudeRef === GPSDirection.West && longitude > 0) {  
  longitude = -longitude
}
```

This fix handles both EXIF coordinate formats correctly:
- For unsigned coordinates with references: applies the directional sign
- For already-signed coordinates: preserves the existing sign regardless of reference field

## Files Changed
- `apps/web/src/lib/map-utils.ts` - Fixed coordinate conversion logic in `convertExifGPSToDecimal` function