### PR TITLE
fix: thumbnails cache not working when digest suffix is enabled

### DIFF
--- a/packages/builder/src/photo/cache-manager.ts
+++ b/packages/builder/src/photo/cache-manager.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 
 import { thumbnailExists } from '../image/thumbnail.js'
 import type { PhotoManifestItem } from '../types/photo.js'
@@ -19,13 +18,11 @@ export interface CacheableData {
  * 考虑文件更新状态和缓存存在性
  */
 export async function shouldProcessPhoto(
-  photoKey: string,
+  photoId: string,
   existingItem: PhotoManifestItem | undefined,
   obj: { LastModified?: Date; ETag?: string },
   options: PhotoProcessorOptions,
 ): Promise<{ shouldProcess: boolean; reason: string }> {
-  const photoId = path.basename(photoKey, path.extname(photoKey))
-
   // 强制模式下总是处理
   if (options.isForceMode) {
     return { shouldProcess: true, reason: '强制模式' }

--- a/packages/builder/src/photo/image-pipeline.ts
+++ b/packages/builder/src/photo/image-pipeline.ts
@@ -133,7 +133,7 @@ export async function processImageWithSharp(
  * @param s3Key S3键
  * @returns 带摘要后缀的ID
  */
-function generatePhotoId(s3Key: string): string {
+async function generatePhotoId(s3Key: string): Promise<string> {
   const { options } = defaultBuilder.getConfig()
   const { digestSuffixLength } = options
   if (!digestSuffixLength || digestSuffixLength <= 0) {
@@ -157,7 +157,7 @@ export async function executePhotoProcessingPipeline(
   const loggers = getGlobalLoggers()
 
   // Generate the actual photo ID with digest suffix
-  const photoId = generatePhotoId(photoKey)
+  const photoId = await generatePhotoId(photoKey)
 
   try {
     // 1. 预处理图片
@@ -256,9 +256,11 @@ export async function processPhotoWithPipeline(
   const { photoKey, existingItem, obj, options } = context
   const loggers = getGlobalLoggers()
 
+  const photoId = await generatePhotoId(photoKey)
+
   // 检查是否需要处理
   const { shouldProcess, reason } = await shouldProcessPhoto(
-    photoKey,
+    photoId,
     existingItem,
     obj,
     options,


### PR DESCRIPTION
Introduced in #67 

Builder用不带digest的文件名检查thumbnail缓存，导致缓存失效：
```
➜  afilmory git:(fix-cluster-dead-lock) grep DSC_9527 /tmp/build.log              
[WORKER-58:IMAGE] ℹ 📸 [141/342] 20250130_towers/towers/DSC_9527.jpg
[WORKER-58:IMAGE] ℹ 🔄 更新照片 (缩略图缺失)：20250130_towers/towers/DSC_9527.jpg
[S3] ℹ 下载文件：20250130_towers/towers/DSC_9527.jpg
[S3] ✔ 下载完成：20250130_towers/towers/DSC_9527.jpg (10522KB, 13396ms)
[WORKER-58:BLURHASH] ℹ 复用现有 blurhash: DSC_9527_1d8d72f6
[WORKER-58:THUMBNAIL] ℹ 复用现有缩略图：DSC_9527_1d8d72f6
[WORKER-58:EXIF] ℹ 复用现有 EXIF 数据：DSC_9527
[WORKER-58:TONE] ℹ 复用现有影调分析：DSC_9527
[WORKER-58:IMAGE] ℹ 提取照片信息：20250130_towers/towers/DSC_9527.jpg
[WORKER-58:IMAGE] ✔ ✅ 处理完成：20250130_towers/towers/DSC_9527.jpg
✅ 转换成功：DSC_9527_1d8d72f6.webp -> DSC_9527_1d8d72f6.jpg
```

可以同时看到 `更新照片 (缩略图缺失)` 和 `复用现有缩略图`