### PR TITLE
fix: local file storage provider 404 with prod

### DIFF
--- a/apps/ssr/scripts/build.sh
+++ b/apps/ssr/scripts/build.sh
@@ -5,6 +5,15 @@ pnpm build
 
 rm -rf ../ssr/public
 cp -r dist ../ssr/public
+# Copy repository photos into SSR public so Next.js can serve /photos/* in production
+# If the photos directory does not exist, continue without failing the build
+if [ -d "../../photos" ]; then
+	echo "Copying photos/ -> ../ssr/public/photos"
+	rm -rf ../ssr/public/photos
+	cp -r ../../photos ../ssr/public/photos
+else
+	echo "No photos/ directory found at repository root; skipping copy."
+fi
 cd ../ssr
 # Convert HTML to JS format with exported string
 node -e "


### PR DESCRIPTION
在配置使用 local 本地存储为 storage provider 后，build 完成会发现本地文件无法访问到，原因为没有移动至 public 目录下，经过修复后恢复正常。  
```
{
  "storage": {
    "provider": "local",
    "basePath": "./photos",
    "baseUrl": "http://localhost:3000/photos"
  }
}
```

修复前：  
<img width="2469" height="1274" alt="image" src="https://github.com/user-attachments/assets/09b44fad-810b-499a-9bce-4002756c6021" />


修复后：  
<img width="931" height="456" alt="image" src="https://github.com/user-attachments/assets/26aa73c9-6323-464e-9dfc-a8a8671a8150" />
