### PR TITLE
fix live photo detection with capital letter

### DIFF
--- a/packages/builder/src/storage/providers/github-provider.ts
+++ b/packages/builder/src/storage/providers/github-provider.ts
@@ -242,7 +242,8 @@ export class GitHubStorageProvider implements StorageProvider {
       if (!obj.key) continue
 
       const dir = path.dirname(obj.key)
-      const basename = path.basename(obj.key, path.extname(obj.key))
+      // use path.parse to safely get the filename without extension (case-insensitive extension handling)
+      const basename = path.parse(obj.key).name
       const groupKey = `${dir}/${basename}`
 
       if (!fileGroups.has(groupKey)) {

--- a/packages/builder/src/storage/providers/local-provider.ts
+++ b/packages/builder/src/storage/providers/local-provider.ts
@@ -244,7 +244,9 @@ export class LocalStorageProvider implements StorageProvider {
 
       // 如果是图片文件，查找对应的视频文件
       if (SUPPORTED_FORMATS.has(ext)) {
-        const baseName = path.basename(obj.key, ext)
+        // use path.parse to get the name without extension to avoid issues
+        // when the file extension has different casing (e.g. .HEIC)
+        const baseName = path.parse(obj.key).name
         const dirName = path.dirname(obj.key)
 
         // 查找对应的 .mov 文件

--- a/packages/builder/src/storage/providers/s3-provider.ts
+++ b/packages/builder/src/storage/providers/s3-provider.ts
@@ -229,7 +229,7 @@ export class S3StorageProvider implements StorageProvider {
       if (!obj.key) continue
 
       const dir = path.dirname(obj.key)
-      const basename = path.basename(obj.key, path.extname(obj.key))
+      const basename = path.parse(obj.key).name
       const groupKey = `${dir}/${basename}`
 
       if (!fileGroups.has(groupKey)) {


### PR DESCRIPTION
## 原因：
Live Photo 的检测逻辑基于“图片文件”和同名的 .mov 文件配对。代码在将文件分组时使用了 path.basename(obj.key, path.extname(obj.key)) 或 path.basename(..., ext) 提取不含扩展名的 basename。
由于某些文件在仓库中是大写扩展名（例如 IMG_4757.HEIC），path.extname 返回 .HEIC（大写），在做 toLowerCase()/SUPPORTED_FORMATS 等判断时会正确识别图片，但在生成 group key 时按原始大小写的扩展去除可能导致同名 .mov（小写）匹配失败，从而漏检 Live Photo 配对

## 解决思路：
统一使用 path.parse(obj.key).name 来取不带扩展的文件名（不依赖 ext 的大小写），并在分组时使用该 name。这解决了扩展名大小写不一致导致的配对失败

## 修改前
<img width="773" height="356" alt="image" src="https://github.com/user-attachments/assets/2ba8e6cf-3fc3-4f02-85fc-e74917e2a1ea" />


## 修改后
<img width="669" height="308" alt="image" src="https://github.com/user-attachments/assets/6a7211c2-2c28-4747-8cb0-cc6bdcaccf1f" />
