### PR TITLE
feat: add map projection mode support

### DIFF
--- a/apps/web/src/components/ui/map/MapLibre.tsx
+++ b/apps/web/src/components/ui/map/MapLibre.tsx
@@ -1,6 +1,7 @@
 // Styles
 import 'maplibre-gl/dist/maplibre-gl.css'
 
+import { siteConfig } from '@config'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Map from 'react-map-gl/maplibre'
 
@@ -199,6 +200,13 @@ export const Maplibre = ({
   // 当地图加载完成时触发适配
   const handleMapLoad = useCallback(() => {
     setIsMapLoaded(true)
+    if (mapRef?.current?.getMap) {
+      const map = mapRef.current.getMap()
+      const projectionType = siteConfig.mapProjection || 'mercator'
+      map.setProjection({
+        type: projectionType,
+      })
+    }
   }, [])
 
   // 当标记点变化时，重新适配边界

--- a/config.example.json
+++ b/config.example.json
@@ -12,5 +12,6 @@
   "map": [
     "maplibre"
   ],
-  "mapStyle": "builtin"
+  "mapStyle": "builtin",
+  "mapProjection": "mercator"
 }

--- a/site.config.ts
+++ b/site.config.ts
@@ -13,6 +13,7 @@ export interface SiteConfig {
   feed?: Feed
   map?: MapConfig
   mapStyle?: string
+  mapProjection?: 'globe' | 'mercator'
 }
 
 /**


### PR DESCRIPTION
现在可以设置地图的投影模式，可选 墨卡托投影（默认）和 球体模式

球体模式效果如下：

<img width="2992" height="1943" alt="image" src="https://github.com/user-attachments/assets/c15d5bc6-fed0-4627-9cf8-a31a08f04642" />
