### PR TITLE
fix: manifest saving on load failure and thumbnail removal

### DIFF
--- a/packages/builder/src/manifest/manager.ts
+++ b/packages/builder/src/manifest/manager.ts
@@ -88,7 +88,7 @@ export async function handleDeletedPhotos(items: PhotoManifestItem[]): Promise<n
   logger.main.info('🔍 检查已删除的图片...')
   if (items.length === 0) {
     // Clear all thumbnails
-    await fs.rm(path.join(workdir, 'public/thumbnails'), { recursive: true })
+    await fs.rm(path.join(workdir, 'public/thumbnails'), { recursive: true, force: true })
     logger.main.info('🔍 没有图片，清空缩略图...')
     return 0
   }


### PR DESCRIPTION
Ensure the manifest is saved when loading fails and force removal of thumbnails when no items are present.

Also related to https://github.com/Afilmory/afilmory/pull/120