### PR TITLE
Fix import path for handler in dev.ts

### DIFF
--- a/apps/ssr/src/app/photos/[photoId]/dev.ts
+++ b/apps/ssr/src/app/photos/[photoId]/dev.ts
@@ -1,1 +1,1 @@
-export { handler } from '../[...all]/dev'
+export { handler } from '../../[...all]/dev'


### PR DESCRIPTION
When I try to start the repo on my mac, it kept console an ssr error. So I drafted this tiny PR to fix the "Module not found" error

<img width="561" height="112" alt="image" src="https://github.com/user-attachments/assets/32c28dac-f4e7-46e1-9265-fea3fd23fc0c" />
