### PR TITLE
fix: update modal imports to use the new path structure to solve #184

### DIFF
--- a/be/apps/dashboard/src/modules/photos/components/library/PhotoExifDetailsModal.tsx
+++ b/be/apps/dashboard/src/modules/photos/components/library/PhotoExifDetailsModal.tsx
@@ -1,6 +1,7 @@
 import type { PhotoManifestItem, PickedExif } from '@afilmory/builder'
 import type { ModalComponent } from '@afilmory/ui'
-import { DialogDescription, DialogHeader, DialogTitle, LinearDivider, ScrollArea } from '@afilmory/ui'
+import { LinearDivider, ScrollArea } from '@afilmory/ui'
+import { DialogDescription, DialogHeader, DialogTitle } from '@afilmory/ui/modal/Dialog.jsx'
 import { clsxm } from '@afilmory/utils'
 import { useTranslation } from 'react-i18next'
 

--- a/be/apps/dashboard/src/modules/photos/components/library/PhotoTagEditorModal.tsx
+++ b/be/apps/dashboard/src/modules/photos/components/library/PhotoTagEditorModal.tsx
@@ -1,5 +1,6 @@
 import type { ModalComponent } from '@afilmory/ui'
-import { Button, DialogDescription, DialogFooter, DialogHeader, DialogTitle, LinearDivider } from '@afilmory/ui'
+import { Button, LinearDivider } from '@afilmory/ui'
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@afilmory/ui/modal/Dialog.jsx'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'

--- a/be/apps/dashboard/src/modules/storage-providers/components/ManagedStoragePlansModal.tsx
+++ b/be/apps/dashboard/src/modules/storage-providers/components/ManagedStoragePlansModal.tsx
@@ -1,5 +1,6 @@
 import type { ModalComponent } from '@afilmory/ui'
-import { Button, DialogDescription, DialogHeader, DialogTitle } from '@afilmory/ui'
+import { Button } from '@afilmory/ui'
+import { DialogDescription, DialogHeader, DialogTitle } from '@afilmory/ui/modal/Dialog.jsx'
 import { clsxm } from '@afilmory/utils'
 import { useQueryClient } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'

--- a/be/apps/dashboard/src/modules/super-admin/components/TenantDetailModal.tsx
+++ b/be/apps/dashboard/src/modules/super-admin/components/TenantDetailModal.tsx
@@ -1,5 +1,5 @@
 import type { ModalComponent } from '@afilmory/ui'
-import { DialogDescription, DialogHeader, DialogTitle } from '@afilmory/ui'
+import { DialogDescription, DialogHeader, DialogTitle } from '@afilmory/ui/modal/Dialog.jsx'
 import { useTranslation } from 'react-i18next'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'


### PR DESCRIPTION
This pull request updates several modal components to improve code organization and maintainability. The main change is refactoring imports for dialog-related UI components so that they consistently import from the dedicated `@afilmory/ui/modal/Dialog.jsx` module instead of the broader `@afilmory/ui` package.

**UI Component Import Refactoring:**

* Updated `PhotoExifDetailsModal.tsx` to import `DialogDescription`, `DialogHeader`, and `DialogTitle` from `@afilmory/ui/modal/Dialog.jsx` instead of `@afilmory/ui`.
* Updated `PhotoTagEditorModal.tsx` to import dialog components (`DialogDescription`, `DialogFooter`, `DialogHeader`, `DialogTitle`) from `@afilmory/ui/modal/Dialog.jsx`.
* Updated `ManagedStoragePlansModal.tsx` to import dialog components from `@afilmory/ui/modal/Dialog.jsx`.
* Updated `TenantDetailModal.tsx` to import dialog components from `@afilmory/ui/modal/Dialog.jsx`.