### PR TITLE
fix: correct gutter value type in Masonry component

### DIFF
--- a/apps/web/src/entries/share/components/MasonryGallery.tsx
+++ b/apps/web/src/entries/share/components/MasonryGallery.tsx
@@ -19,7 +19,7 @@ export function MasonryGallery({ photos }: MasonryGalleryProps) {
   }, [width])
   return (
     <div className="scrollbar-none h-screen overflow-auto">
-      <Masonry gutter={4} columnsCount={columnsCount}>
+      <Masonry gutter="4px" columnsCount={columnsCount}>
         {photos.map((photo) => (
           <PhotoItem key={photo.id} photo={photo} />
         ))}


### PR DESCRIPTION

```log

transforming (4480) ../../node_modules/.pnpm/@ant-design+icons-svgsrc/entries/share/components/MasonryGallery.tsx:22:16 - error TS2322: Type 'number' is not assignable to type 'string'.

22       <Masonry gutter={4} columnsCount={columnsCount}>
                  ~~~~~~

  ../../node_modules/.pnpm/@types+react-responsive-masonry@2.7.0/node_modules/@types/react-responsive-masonry/index.d.ts:16:5
    16     gutter?: string;
           ~~~~~~
    The expected type comes from property 'gutter' which is declared here on type 'IntrinsicAttributes & MasonryProps.'


Found 1 error in src/entries/share/components/MasonryGallery.tsx:22

ExecaError: Command failed with exit code 2: vite build
```