### PR TITLE
fix: exit animation target on ListView

### DIFF
--- a/apps/web/src/modules/gallery/ListView.tsx
+++ b/apps/web/src/modules/gallery/ListView.tsx
@@ -193,6 +193,7 @@ const PhotoCard = ({ photo }: { photo: PhotoManifest }) => {
         className="relative w-full shrink-0 cursor-pointer overflow-hidden lg:h-full lg:w-56"
         role="button"
         tabIndex={0}
+        data-photo-id={photo.id}
         style={
           // 移动端：根据宽高比计算高度
           {

--- a/apps/web/src/modules/viewer/animations/usePhotoViewerTransitions.ts
+++ b/apps/web/src/modules/viewer/animations/usePhotoViewerTransitions.ts
@@ -69,7 +69,11 @@ export const usePhotoViewerTransitions = ({
   const resolveTriggerElement = useCallback((): HTMLElement | null => {
     if (!currentPhoto) return null
 
-    if (triggerElement && triggerElement.isConnected) {
+    const isElementForCurrentPhoto = (el: HTMLElement) => {
+      return el.dataset.photoId === currentPhoto.id
+    }
+
+    if (triggerElement && triggerElement.isConnected && isElementForCurrentPhoto(triggerElement)) {
       cachedTriggerRef.current = triggerElement
       return triggerElement
     }
@@ -82,7 +86,11 @@ export const usePhotoViewerTransitions = ({
       return liveTriggerEl
     }
 
-    if (cachedTriggerRef.current && cachedTriggerRef.current.isConnected) {
+    if (
+      cachedTriggerRef.current &&
+      cachedTriggerRef.current.isConnected &&
+      isElementForCurrentPhoto(cachedTriggerRef.current)
+    ) {
       return cachedTriggerRef.current
     }
 


### PR DESCRIPTION
This fixes a bug where the exit animation would fly to the original opening photo on ListView.

Changes:
- Add 'data-photo-id' attribute to ListView items to support this verification same as MasonryView.

Before:

https://github.com/user-attachments/assets/51fdc4bb-c3f3-4c17-99d3-cfa2d8b1a4d8

After:

https://github.com/user-attachments/assets/7407ce76-c2b0-4505-80e1-c50c712fee3c


