### PR TITLE
feat(builder): add mp4 extension support for Live Photos in storage providers

### DIFF
--- a/packages/builder/src/storage/providers/b2-provider.ts
+++ b/packages/builder/src/storage/providers/b2-provider.ts
@@ -536,7 +536,7 @@ export class B2StorageProvider implements StorageProvider {
         const ext = path.extname(file.key).toLowerCase()
         if (SUPPORTED_FORMATS.has(ext)) {
           imageFile = file
-        } else if (ext === '.mov') {
+        } else if (ext === '.mov' || ext === '.mp4') {
           videoFile = file
         }
       }

--- a/packages/builder/src/storage/providers/github-provider.ts
+++ b/packages/builder/src/storage/providers/github-provider.ts
@@ -390,8 +390,8 @@ export class GitHubStorageProvider implements StorageProvider {
         if (SUPPORTED_FORMATS.has(ext)) {
           imageFile = file
         }
-        // 检查是否为 .mov 视频文件
-        else if (ext === '.mov') {
+        // 检查是否为 .mov 或 .mp4 视频文件
+        else if (ext === '.mov' || ext === '.mp4') {
           videoFile = file
         }
       }

--- a/packages/builder/src/storage/providers/local-provider.ts
+++ b/packages/builder/src/storage/providers/local-provider.ts
@@ -353,12 +353,16 @@ export class LocalStorageProvider implements StorageProvider {
         const baseName = path.parse(obj.key).name
         const dirName = path.dirname(obj.key)
 
-        // 查找对应的 .mov 文件
-        const videoKey = path.join(dirName, `${baseName}.mov`).replaceAll('\\', '/')
-        const videoObj = fileMap.get(videoKey.toLowerCase())
+        // 查找对应的 .mov 或 .mp4 文件
+        const videoExtensions = ['.mov', '.mp4']
+        for (const videoExt of videoExtensions) {
+          const videoKey = path.join(dirName, `${baseName}${videoExt}`).replaceAll('\\', '/')
+          const videoObj = fileMap.get(videoKey.toLowerCase())
 
-        if (videoObj) {
-          livePhotos.set(obj.key, videoObj)
+          if (videoObj) {
+            livePhotos.set(obj.key, videoObj)
+            break
+          }
         }
       }
     })

--- a/packages/builder/src/storage/providers/s3-provider.ts
+++ b/packages/builder/src/storage/providers/s3-provider.ts
@@ -287,8 +287,8 @@ export class S3StorageProvider implements StorageProvider {
         if (SUPPORTED_FORMATS.has(ext)) {
           imageFile = file
         }
-        // 检查是否为 .mov 视频文件
-        else if (ext === '.mov') {
+        // 检查是否为 .mov 或 .mp4 视频文件
+        else if (ext === '.mov' || ext === '.mp4') {
           videoFile = file
         }
       }


### PR DESCRIPTION
Support mp4 files as Live Photo companions alongside mov files across all storage providers (local, S3, B2, GitHub). This allows users to store Live Photos with mp4 video files in addition to the existing mov format.
Because I found that the live photos exported from vivo phones are in jpg and mp4 formats, but they are currently not supported.