### PR TITLE
feat(ui): implement reduced motion support

### DIFF
--- a/apps/web/src/components/ui/number/SlidingNumber.tsx
+++ b/apps/web/src/components/ui/number/SlidingNumber.tsx
@@ -2,7 +2,7 @@
 
 import { clsxm, Spring } from '@afilmory/utils'
 import type { MotionValue, SpringOptions, UseInViewOptions } from 'motion/react'
-import { m as motion, useInView, useSpring, useTransform } from 'motion/react'
+import { m as motion, useInView, useReducedMotion, useSpring, useTransform } from 'motion/react'
 import * as React from 'react'
 import useMeasure from 'react-use-measure'
 
@@ -16,7 +16,12 @@ type SlidingNumberRollerProps = {
 function SlidingNumberRoller({ prevValue, value, place, transition }: SlidingNumberRollerProps) {
   const startNumber = Math.floor(prevValue / place) % 10
   const targetNumber = Math.floor(value / place) % 10
-  const animatedValue = useSpring(startNumber, transition)
+  const shouldReduceMotion = useReducedMotion()
+
+  const animatedValue = useSpring(
+    shouldReduceMotion ? targetNumber : startNumber,
+    shouldReduceMotion ? { duration: 0 } : transition,
+  )
 
   React.useEffect(() => {
     animatedValue.set(targetNumber)

--- a/apps/web/src/providers/root-providers.tsx
+++ b/apps/web/src/providers/root-providers.tsx
@@ -19,7 +19,7 @@ const CloudSessionProvider = withCloud(SessionProvider)
 export const RootProviders: FC<PropsWithChildren> = ({ children }) => {
   return (
     <LazyMotion features={domMax} strict key="framer">
-      <MotionConfig transition={Spring.presets.smooth}>
+      <MotionConfig transition={Spring.presets.smooth} reducedMotion="user">
         <Provider store={jotaiStore}>
           <QueryProvider>
             <CloudSessionProvider />


### PR DESCRIPTION
当用户的操作系统开启了 "减弱动态效果" ([prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion)) 时，禁用大部分动画，以避免引起部分用户的不适（如眩晕），同时减轻性能开销。这个效果和 [MapLibre 默认](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/AnimationOptions/#essential) 一致。