### PR TITLE
[add] a trivial way to support GIF

### DIFF
--- a/apps/web/src/modules/viewer/PhotoViewer.tsx
+++ b/apps/web/src/modules/viewer/PhotoViewer.tsx
@@ -347,6 +347,7 @@ export const PhotoViewer = ({
                               shouldAutoPlayVideoOnce={isCurrentImage}
                               // HDR props
                               isHDR={photo.isHDR}
+                              isGIF={photo.format === 'GIF'}
                             />
                           </m.div>
                         </SwiperSlide>

--- a/apps/web/src/modules/viewer/ProgressiveImage.tsx
+++ b/apps/web/src/modules/viewer/ProgressiveImage.tsx
@@ -148,7 +148,7 @@ export const ProgressiveImage = ({
           }}
         >
           {/* LivePhoto/Motion Photo 或 HDR 模式使用 DOMImageViewer */}
-          {hasVideo || shouldUseHDR ? (
+          {hasVideo || shouldUseHDR || isGIF ? (
             <DOMImageViewer
               ref={domImageViewerRef}
               onZoomChange={onDOMTransformed}
@@ -172,14 +172,6 @@ export const ProgressiveImage = ({
                 />
               )}
             </DOMImageViewer>
-          ) : isGIF ? (
-            <img
-              src={blobSrc}
-              alt={alt}
-              className="absolute inset-0 h-full w-full object-contain"
-              width={width}
-              height={height}
-            />
           ) : (
             /* 非 LivePhoto 模式使用 WebGLImageViewer */
             <WebGLImageViewer

--- a/apps/web/src/modules/viewer/ProgressiveImage.tsx
+++ b/apps/web/src/modules/viewer/ProgressiveImage.tsx
@@ -42,6 +42,7 @@ export const ProgressiveImage = ({
   videoSource,
   shouldAutoPlayVideoOnce = false,
   isHDR = false,
+  isGIF = false,
   loadingIndicatorRef,
 }: ProgressiveImageProps) => {
   const { t } = useTranslation()
@@ -171,6 +172,14 @@ export const ProgressiveImage = ({
                 />
               )}
             </DOMImageViewer>
+          ) : isGIF ? (
+            <img
+              src={blobSrc}
+              alt={alt}
+              className="absolute inset-0 h-full w-full object-contain"
+              width={width}
+              height={height}
+            />
           ) : (
             /* 非 LivePhoto 模式使用 WebGLImageViewer */
             <WebGLImageViewer

--- a/apps/web/src/modules/viewer/types.ts
+++ b/apps/web/src/modules/viewer/types.ts
@@ -39,6 +39,8 @@ export interface ProgressiveImageProps {
   // HDR 相关 props
   isHDR?: boolean
 
+  isGIF?: boolean
+
   loadingIndicatorRef: React.RefObject<LoadingIndicatorRef | null>
 }
 

--- a/packages/builder/src/constants/index.ts
+++ b/packages/builder/src/constants/index.ts
@@ -10,6 +10,7 @@ export const SUPPORTED_FORMATS = new Set([
   '.heif',
   '.hif',
   '.tif',
+  '.gif',
 ])
 
 // HEIC/HEIF 格式


### PR DESCRIPTION
Currently, the GIF is rendered using `WebGLImageViewer`. [For example
](https://chunibyo.afilmory.art/photos/loss_github_light)

Add a temporary solution to support GIF using the image tag.

