### PR TITLE
feat: Add configurable ICP beian footer for China mainland

### DIFF
--- a/apps/web/src/modules/gallery/PageFooter.tsx
+++ b/apps/web/src/modules/gallery/PageFooter.tsx
@@ -1,0 +1,67 @@
+import { LinearBlur } from '@afilmory/ui'
+
+import siteConfig from '~/../../site.config'
+
+export const PageFooter = () => {
+  const { beian } = siteConfig
+
+  // 如果 ICP 和公安备案都未启用，不渲染组件
+  const showICP = beian?.icp?.enabled && beian?.icp?.number
+  const showPolice = beian?.police?.enabled && beian?.police?.number
+
+  if (!showICP && !showPolice) {
+    return null
+  }
+
+  // 是否显示两行（同时启用 ICP 和公安备案）
+  const isTwoLine = showICP && showPolice
+
+  return (
+    <footer className="pointer-events-none fixed inset-x-0 bottom-0 z-100">
+      <LinearBlur
+        className="absolute inset-x-0 bottom-0 z-[-1] h-20"
+        tint="var(--color-background)"
+        strength={isTwoLine ? 96 : 128}
+        falloffPercentage={100}
+        side="bottom"
+      />
+
+      <div
+        className={`pointer-events-auto flex items-center justify-center gap-1 px-3 lg:px-4 ${
+          isTwoLine ? 'h-16 flex-col lg:h-16' : 'h-10 lg:h-10'
+        }`}
+      >
+        {/* 公安备案 */}
+        {showPolice && (
+          <div className="flex items-center gap-1.5">
+            {beian?.police?.icon && <img src={beian?.police?.icon} alt="公安备案图标" className="size-4" />}
+            <a
+              href={
+                beian?.police?.code
+                  ? `https://beian.mps.gov.cn/#/query/webSearch?code=${beian?.police?.code}`
+                  : undefined
+              }
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-white/60 transition-colors duration-200 hover:text-white"
+            >
+              {beian?.police?.number}
+            </a>
+          </div>
+        )}
+
+        {/* ICP备案 */}
+        {showICP && (
+          <a
+            href={beian?.icp?.link || 'https://beian.miit.gov.cn/'}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-white/60 transition-colors duration-200 hover:text-white"
+          >
+            {beian?.icp?.number}
+          </a>
+        )}
+      </div>
+    </footer>
+  )
+}

--- a/apps/web/src/modules/gallery/PhotosRoot.tsx
+++ b/apps/web/src/modules/gallery/PhotosRoot.tsx
@@ -13,6 +13,7 @@ import { ActionPanel } from './ActionPanel'
 import { ActiveFiltersHero } from './ActiveFiltersHero'
 import { ListView } from './ListView'
 import { MasonryView } from './MasonryView'
+import { PageFooter } from './PageFooter'
 import { PageHeader } from './PageHeader'
 
 export const PhotosRoot = () => {
@@ -52,9 +53,11 @@ export const PhotosRoot = () => {
 
       {hasActiveFilters && <ActiveFiltersHero />}
 
-      <div className={clsx('p-1 **:select-none! lg:px-0 lg:pb-0', !hasActiveFilters && 'mt-12')}>
+      <div className={clsx('p-1 **:select-none! lg:px-0', 'pb-20 lg:pb-24', !hasActiveFilters && 'mt-12')}>
         {viewMode === 'list' ? <ListView photos={photos} /> : <MasonryView photos={photos} onRender={handleRender} />}
       </div>
+
+      <PageFooter />
 
       <ActionPanel
         open={!!activePanel}

--- a/config.example.json
+++ b/config.example.json
@@ -25,5 +25,18 @@
     "maplibre"
   ],
   "mapStyle": "builtin",
-  "mapProjection": "mercator"
+  "mapProjection": "mercator",
+  "beian": {
+    "icp": {
+      "enabled": false,
+      "number": "XICP备xxxxxxxx号",
+      "link": "https://beian.miit.gov.cn/"
+    },
+    "police": {
+      "enabled": false,
+      "number": "X公网安备xxxxxxxxxxxxxx号",
+      "code": "xxxxxxxxxxxxxx",
+      "icon": "https://example.com/beian.png"
+    }
+  }
 }

--- a/packages/ui/src/progressive-blur/index.tsx
+++ b/packages/ui/src/progressive-blur/index.tsx
@@ -71,7 +71,15 @@ export function LinearBlur({
             />
           ))}
         <div
-          className="absolute -top-full left-0 size-full"
+          className={`absolute size-full ${
+            side === 'top'
+              ? '-top-full left-0'
+              : side === 'bottom'
+                ? '-bottom-full left-0'
+                : side === 'left'
+                  ? '-left-full top-0'
+                  : '-right-full top-0'
+          }`}
           style={{ boxShadow: `0 0 60px ${tint}, 0 0 100px ${tint}` }}
         />
       </div>

--- a/site.config.ts
+++ b/site.config.ts
@@ -14,6 +14,43 @@ export interface SiteConfig {
   map?: MapConfig
   mapStyle?: string
   mapProjection?: 'globe' | 'mercator'
+  beian?: BeianConfig
+}
+
+/**
+ * ICP备案配置（中国大陆网站备案）
+ */
+interface ICPBeian {
+  /** 是否启用ICP备案显示 */
+  enabled?: boolean
+  /** ICP备案号 */
+  number?: string
+  /** ICP备案查询链接（默认：https://beian.miit.gov.cn/） */
+  link?: string
+}
+
+/**
+ * 公安备案配置
+ */
+interface PoliceBeian {
+  /** 是否启用公安备案显示 */
+  enabled?: boolean
+  /** 公安备案号文本 */
+  number?: string
+  /** 公安备案代码（用于查询链接） */
+  code?: string
+  /** 公安备案图标链接 */
+  icon?: string
+}
+
+/**
+ * 备案配置（中国大陆网站需要）
+ */
+interface BeianConfig {
+  /** ICP备案配置 */
+  icp?: ICPBeian
+  /** 公安备案配置 */
+  police?: PoliceBeian
 }
 
 /**


### PR DESCRIPTION
- Add beian configuration types to SiteConfig (ICP & police beian)
- Create PageFooter component with auto-hide when disabled
- Support flexible layout (single-line ICP or dual-line ICP+police)
- Fix LinearBlur bottom-side shadow positioning issue
- Update PhotosRoot to include PageFooter with proper spacing
- Add beian config examples in config.example.json (disabled by default)

This feature is optional and disabled by default, ensuring backward compatibility. Useful for users deploying in China mainland who need to display ICP beian.