### PR TITLE
feat: auto-fetch demo photos from remote repo during preview build

### DIFF
--- a/scripts/prepare-demo-data.sh
+++ b/scripts/prepare-demo-data.sh
@@ -1,6 +1,17 @@
 #! /bin/bash
 
-cp -r photos ./apps/web/public/photos
+set -e
+
+# Clone demo photos from remote repo if local photos directory is empty
+if [ ! -d "photos" ] || [ -z "$(ls -A photos 2>/dev/null)" ]; then
+  echo "Fetching demo photos from https://github.com/Afilmory/demo-photos..."
+  rm -rf photos
+  git clone --depth 1 https://github.com/Afilmory/demo-photos photos
+  rm -rf photos/.git
+fi
+
+mkdir -p ./apps/web/public/photos
+cp -r photos/* ./apps/web/public/photos/
 
 echo 'import { defineBuilderConfig } from "@afilmory/builder";
 


### PR DESCRIPTION
When the local photos/ directory is empty (as on Vercel), the
prepare-demo-data script now clones Afilmory/demo-photos so that
preview deployments include demo images.

https://claude.ai/code/session_01ABc59z291dhkwRXJ1g8XhS