### PR TITLE
fix: expose App Store auth routes

### DIFF
--- a/apps/mobile/src/modules/auth/api.ts
+++ b/apps/mobile/src/modules/auth/api.ts
@@ -70,7 +70,7 @@ export async function exchangeAppleAuthorization(
   cookie: string,
   input: { authorizationCode: string, identityToken: string, nonce: string },
 ): Promise<void> {
-  await ofetch(`${getApiBaseUrl()}/auth/apple/exchange`, {
+  await ofetch(`${getApiBaseUrl()}/mobile-auth/apple/exchange`, {
     body: input,
     headers: { cookie },
     method: 'POST',
@@ -78,7 +78,7 @@ export async function exchangeAppleAuthorization(
 }
 
 export async function fetchAppleAuthenticationConfiguration(): Promise<AppleAuthenticationConfiguration> {
-  const raw = await ofetch<unknown>(`${getApiBaseUrl()}/auth/apple/configuration`)
+  const raw = await ofetch<unknown>(`${getApiBaseUrl()}/mobile-auth/apple/configuration`)
   return camelCaseKeys<AppleAuthenticationConfiguration>(raw)
 }
 
@@ -94,7 +94,7 @@ export async function createWorkspace(cookie: string, input: { name: string, slu
 }
 
 export async function fetchAccountDeletionImpact(cookie: string): Promise<AccountDeletionImpact> {
-  const raw = await ofetch<unknown>(`${getApiBaseUrl()}/auth/account-deletion/impact`, {
+  const raw = await ofetch<unknown>(`${getApiBaseUrl()}/account-deletion/impact`, {
     headers: { cookie },
   })
   return camelCaseKeys<AccountDeletionImpact>(raw)
@@ -104,7 +104,7 @@ export async function requestAccountDeletion(
   cookie: string,
   proof: AccountDeletionProof,
 ): Promise<AccountDeletionRequestResult> {
-  const raw = await ofetch<unknown>(`${getApiBaseUrl()}/auth/account-deletion/request`, {
+  const raw = await ofetch<unknown>(`${getApiBaseUrl()}/account-deletion/request`, {
     body: { proof },
     headers: { cookie },
     method: 'POST',

--- a/be/apps/core/src/modules/platform/account-deletion/account-deletion.controller.ts
+++ b/be/apps/core/src/modules/platform/account-deletion/account-deletion.controller.ts
@@ -10,7 +10,8 @@ import { parseAccountDeletionProof } from './account-deletion-proof'
 import { AccountDeletionRequestService } from './account-deletion-request.service'
 
 @injectable()
-@Controller('auth/account-deletion')
+// This domain endpoint must not sit below Better Auth's `/auth/*` passthrough.
+@Controller('account-deletion')
 export class AccountDeletionController {
   constructor(
     private readonly impact: AccountDeletionImpactService,

--- a/be/apps/core/src/modules/platform/auth/apple-auth.controller.ts
+++ b/be/apps/core/src/modules/platform/auth/apple-auth.controller.ts
@@ -9,7 +9,10 @@ import type { AppleAuthorizationInput } from './apple-authorization.service'
 import { AppleAuthorizationService } from './apple-authorization.service'
 
 @injectable()
-@Controller('auth/apple')
+// Keep native Apple exchange routes outside Better Auth's `/auth/*` passthrough.
+// Hono resolves routes in registration order, so placing custom endpoints below
+// that namespace makes them unreachable once the passthrough is registered.
+@Controller('mobile-auth/apple')
 export class AppleAuthController {
   constructor(private readonly apple: AppleAuthorizationService) {}
 

--- a/docs/superpowers/specs/2026-08-03-ios-app-store-auth-design.md
+++ b/docs/superpowers/specs/2026-08-03-ios-app-store-auth-design.md
@@ -272,6 +272,12 @@ A native-only deletion call that leaves the JavaScript session intact is not acc
 | Native workspace and profile entry points               | `PhotosHomeController.swift`, `PageControllerHostView.swift`, `ProfileSheetView.swift`, and supporting sheet records                                                                                            |
 | Release operations                                      | `apps/mobile/RELEASE.md` and App Store Connect review metadata                                                                                                                                                  |
 
+Custom mobile authentication endpoints use `/api/mobile-auth/apple/*`, while
+account-deletion endpoints use `/api/account-deletion/*`. They intentionally do
+not live below `/api/auth/*`: that namespace terminates in Better Auth's
+registration-order-sensitive passthrough route and cannot safely host custom
+controllers.
+
 ## Out of Scope
 
 - Public email/password registration, verification email, password reset, and account recovery.


### PR DESCRIPTION
## Summary
- move native Apple exchange/configuration endpoints outside Better Auths catch-all namespace
- move account deletion endpoints outside the same catch-all namespace
- update mobile callers and record the routing constraint in the design spec

## Root cause
`AuthController` registers `/auth/*` before the custom controllers. Hono resolves routes in registration order, so both new endpoint groups were handled by Better Auth and returned 404 even though the new Core container was healthy.

## Validation
- targeted ESLint passed
- mobile TypeScript check passed
- Core production build passed
- production deployment logs for the previous release confirmed migrations and container startup; public smoke tests reproduced the route shadowing