### PR TITLE
feat(mobile): offline-first local cache (SwiftData) + manifest ETag

### DIFF
--- a/apps/mobile/modules/photo-masonry/ios/Core/AfilmoryAPI.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Core/AfilmoryAPI.swift
@@ -23,6 +23,11 @@ private enum AfilmoryAPIConfigurationError: LocalizedError {
   }
 }
 
+enum ManifestFetchOutcome: Sendable {
+  case notModified
+  case success(Data, etag: String?)
+}
+
 final class AfilmoryAPI: @unchecked Sendable {
   static let shared = AfilmoryAPI()
 
@@ -92,36 +97,7 @@ final class AfilmoryAPI: @unchecked Sendable {
   ) async throws -> Response {
     try Task.checkCancellation()
     let sessionSnapshot = sessionSnapshot ?? sessionStore.current()
-    let baseURL = switch endpoint.baseURL {
-    case .platform:
-      sessionSnapshot.platformBaseURL
-    case .tenant:
-      sessionSnapshot.tenantBaseURL
-    case .explicit(let value):
-      value
-    }
-
-    guard let baseURL else {
-      let error: AfilmoryAPIConfigurationError = switch endpoint.baseURL {
-      case .platform: .missingPlatformBaseURL
-      case .tenant: .missingTenantBaseURL
-      case .explicit: .invalidBaseURL
-      }
-      throw APIError.transport(error)
-    }
-    guard var components = URLComponents(
-      string: baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        + "/"
-        + endpoint.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-    ) else {
-      throw APIError.transport(AfilmoryAPIConfigurationError.invalidRequestURL)
-    }
-    if !endpoint.queryItems.isEmpty {
-      components.queryItems = endpoint.queryItems
-    }
-    guard let url = components.url else {
-      throw APIError.transport(AfilmoryAPIConfigurationError.invalidRequestURL)
-    }
+    let url = try resolveURL(for: endpoint, sessionSnapshot: sessionSnapshot)
 
     var request = URLRequest(url: url)
     request.httpMethod = endpoint.method.rawValue
@@ -165,5 +141,74 @@ final class AfilmoryAPI: @unchecked Sendable {
     case .unauthorized, .decoding, .cancelled:
       false
     }
+  }
+
+  func fetchManifest(_ endpoint: APIEndpoint, etag: String?) async throws -> ManifestFetchOutcome {
+    try Task.checkCancellation()
+    let sessionSnapshot = sessionStore.current()
+    let url = try resolveURL(for: endpoint, sessionSnapshot: sessionSnapshot)
+
+    var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
+    request.httpMethod = endpoint.method.rawValue
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    if let etag, !etag.isEmpty {
+      request.setValue(etag, forHTTPHeaderField: "If-None-Match")
+    }
+    if let cookie = sessionSnapshot.cookie, !cookie.isEmpty {
+      request.setValue(cookie, forHTTPHeaderField: "Cookie")
+    }
+
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await session.data(for: request)
+    } catch {
+      throw APIError.request(error)
+    }
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.transport(AfilmoryAPIConfigurationError.nonHTTPResponse)
+    }
+    if httpResponse.statusCode == 304 {
+      return .notModified
+    }
+    if let responseError = APIError.response(status: httpResponse.statusCode, body: data) {
+      throw responseError
+    }
+    return .success(data, etag: httpResponse.value(forHTTPHeaderField: "ETag"))
+  }
+
+  private func resolveURL(for endpoint: APIEndpoint, sessionSnapshot: AfilmorySessionSnapshot) throws -> URL {
+    let baseURL = switch endpoint.baseURL {
+    case .platform:
+      sessionSnapshot.platformBaseURL
+    case .tenant:
+      sessionSnapshot.tenantBaseURL
+    case .explicit(let value):
+      value
+    }
+
+    guard let baseURL else {
+      let error: AfilmoryAPIConfigurationError = switch endpoint.baseURL {
+      case .platform: .missingPlatformBaseURL
+      case .tenant: .missingTenantBaseURL
+      case .explicit: .invalidBaseURL
+      }
+      throw APIError.transport(error)
+    }
+    guard var components = URLComponents(
+      string: baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        + "/"
+        + endpoint.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    ) else {
+      throw APIError.transport(AfilmoryAPIConfigurationError.invalidRequestURL)
+    }
+    if !endpoint.queryItems.isEmpty {
+      components.queryItems = endpoint.queryItems
+    }
+    guard let url = components.url else {
+      throw APIError.transport(AfilmoryAPIConfigurationError.invalidRequestURL)
+    }
+    return url
   }
 }

--- a/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionModule.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionModule.swift
@@ -16,6 +16,7 @@ public final class AfilmorySessionModule: Module {
       Task { @MainActor in
         AfilmorySessionStore.shared.bootstrap()
       }
+      CacheLifecycleCoordinator.shared.runOnce()
     }
 
     OnDestroy {

--- a/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionModule.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionModule.swift
@@ -13,7 +13,9 @@ public final class AfilmorySessionModule: Module {
           self?.sendEvent("onSessionChange", Self.eventPayload(state))
         }
       }
-      AfilmorySessionStore.shared.bootstrap()
+      Task { @MainActor in
+        AfilmorySessionStore.shared.bootstrap()
+      }
     }
 
     OnDestroy {
@@ -74,15 +76,18 @@ public final class AfilmorySessionModule: Module {
   }
 
   private static func eventPayload(_ state: AfilmorySessionState) -> [String: Any] {
-    var payload: [String: Any] = ["status": state.status]
-    if let session = state.session {
-      payload["userId"] = session.user.id
-      payload["workspaceId"] = session.activeWorkspace?.id ?? NSNull()
-      payload["workspaceSlug"] = session.activeWorkspace?.slug ?? NSNull()
-    }
+    var payload: [String: Any] = [
+      "status": state.status,
+      "session": state.session.flatMap(Self.serializedSession) ?? NSNull(),
+    ]
     if case .failed(let message) = state {
       payload["error"] = message
     }
     return payload
+  }
+
+  private static func serializedSession(_ session: AfilmorySession) -> [String: Any]? {
+    guard let data = try? JSONEncoder().encode(session) else { return nil }
+    return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
   }
 }

--- a/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionStore.swift
@@ -8,26 +8,95 @@ struct AfilmorySessionSnapshot: Sendable {
   let state: AfilmorySessionState
 }
 
+typealias AfilmorySessionObserver = @Sendable (AfilmorySessionState) -> Void
+
+protocol SessionTransport: Sendable {
+  func fetchSession() async throws -> AfilmorySessionResponse?
+}
+
+struct LiveSessionTransport: SessionTransport {
+  func fetchSession() async throws -> AfilmorySessionResponse? {
+    try await AfilmoryAPI.shared.request(APIEndpoint(baseURL: .platform, path: "auth/session"))
+  }
+}
+
+protocol SessionCookieStorage: Sendable {
+  func read() -> String?
+  func write(_ cookie: String)
+  func clear()
+}
+
+struct KeychainSessionCookieStorage: SessionCookieStorage {
+  private static let service = "app.afilmory.session.cookie"
+  private static let account = "authenticated-session"
+
+  func read() -> String? {
+    var query = Self.query
+    query[kSecReturnData as String] = true
+    query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+    var result: CFTypeRef?
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+          let data = result as? Data
+    else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  func write(_ cookie: String) {
+    SecItemDelete(Self.query as CFDictionary)
+
+    var attributes = Self.query
+    attributes[kSecValueData as String] = Data(cookie.utf8)
+    // Background upload retries can be recreated while the device is locked.
+    attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+    let status = SecItemAdd(attributes as CFDictionary, nil)
+    if status != errSecSuccess {
+      NSLog("[AfilmorySessionStore] Unable to persist the session cookie: %d", status)
+    }
+  }
+
+  func clear() {
+    let status = SecItemDelete(Self.query as CFDictionary)
+    if status != errSecSuccess, status != errSecItemNotFound {
+      NSLog("[AfilmorySessionStore] Unable to clear the session cookie: %d", status)
+    }
+  }
+
+  private static var query: [String: Any] {
+    [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+    ]
+  }
+}
+
 final class AfilmorySessionStore: @unchecked Sendable {
   static let shared = AfilmorySessionStore()
 
-  private static let cookieService = "app.afilmory.session.cookie"
-  private static let cookieAccount = "authenticated-session"
-
+  private let repository: PhotoCacheRepository
+  private let transport: SessionTransport
+  private let cookieStorage: SessionCookieStorage
   private let lock = NSLock()
   private var platformBaseURL: String?
   private var tenantBaseURL: String?
   private var state: AfilmorySessionState
-  private var observers: [UUID: @Sendable (AfilmorySessionState) -> Void] = [:]
+  private var observers: [UUID: AfilmorySessionObserver] = [:]
   private var refreshTask: Task<Void, Never>?
   private var refreshGeneration: UInt64 = 0
   private var bootstrapped = false
 
-  private init() {
-    let environment = ApiEnvironmentStore.storedOrBuildDefault()
-    platformBaseURL = environment.platformAPIBaseURL().absoluteString
+  init(
+    repository: PhotoCacheRepository = SwiftDataPhotoCacheRepository(container: AfilmoryDatabase.shared),
+    transport: SessionTransport = LiveSessionTransport(),
+    cookieStorage: SessionCookieStorage = KeychainSessionCookieStorage()
+  ) {
+    self.repository = repository
+    self.transport = transport
+    self.cookieStorage = cookieStorage
+    platformBaseURL = ApiEnvironmentStore.storedOrBuildDefault().platformAPIBaseURL().absoluteString
     tenantBaseURL = nil
-    state = Self.readCookie() == nil ? .signedOut : .loading
+    state = cookieStorage.read() == nil ? .signedOut : .loading
   }
 
   func register(cookie: String) {
@@ -36,18 +105,7 @@ final class AfilmorySessionStore: @unchecked Sendable {
       clearSession()
       return
     }
-
-    let query = Self.cookieQuery
-    SecItemDelete(query as CFDictionary)
-
-    var attributes = query
-    attributes[kSecValueData as String] = Data(normalized.utf8)
-    // Background upload retries can be recreated while the device is locked.
-    attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-    let status = SecItemAdd(attributes as CFDictionary, nil)
-    if status != errSecSuccess {
-      NSLog("[AfilmorySessionStore] Unable to persist the session cookie: %d", status)
-    }
+    cookieStorage.write(normalized)
     refreshSession()
   }
 
@@ -60,9 +118,9 @@ final class AfilmorySessionStore: @unchecked Sendable {
 
   func clearSession() {
     APNsRegistrationCoordinator.unregisterCurrentDevice(using: current())
-    deleteCookie()
+    cookieStorage.clear()
     ShareUploadContextStore.clear()
-    let observers = lock.withLock { () -> [@Sendable (AfilmorySessionState) -> Void] in
+    let observers = lock.withLock { () -> [AfilmorySessionObserver] in
       refreshGeneration &+= 1
       refreshTask?.cancel()
       refreshTask = nil
@@ -71,80 +129,39 @@ final class AfilmorySessionStore: @unchecked Sendable {
       return Array(self.observers.values)
     }
     ApiEnvironmentStore.shared.activateTenant(slug: nil)
+    let repository = repository
+    Task { await repository.wipeAll() }
     notify(observers, state: .signedOut)
   }
 
   func current() -> AfilmorySessionSnapshot {
     let environment = lock.withLock { (platformBaseURL, tenantBaseURL) }
     return AfilmorySessionSnapshot(
-      cookie: loadCookie(),
+      cookie: cookieStorage.read(),
       platformBaseURL: environment.0,
       tenantBaseURL: environment.1,
       state: lock.withLock { state }
     )
   }
 
+  @MainActor
   func bootstrap() {
-    let shouldRefresh = lock.withLock { () -> Bool in
+    let shouldStart = lock.withLock { () -> Bool in
       guard !bootstrapped else { return false }
       bootstrapped = true
       return true
     }
-    guard shouldRefresh else { return }
-    refreshSession()
+    guard shouldStart else { return }
+    publishCachedSession()
+    startRefresh(joinInFlight: true)
   }
 
   func refreshSession() {
-    guard loadCookie() != nil else {
-      publish(.signedOut)
-      return
-    }
-
-    let generation = lock.withLock { () -> UInt64 in
-      refreshGeneration &+= 1
-      refreshTask?.cancel()
-      state = .loading
-      return refreshGeneration
-    }
-    publishCurrent()
-
-    let task = Task { [weak self] in
-      guard let self else { return }
-      do {
-        let endpoint = APIEndpoint(baseURL: .platform, path: "auth/session")
-        let response: AfilmorySessionResponse? = try await AfilmoryAPI.shared.request(endpoint)
-        guard !Task.isCancelled else { return }
-        if let session = response?.resolved() {
-          ApiEnvironmentStore.shared.activateTenant(slug: session.activeWorkspace?.slug)
-          completeRefresh(generation: generation, state: .signedIn(session))
-        } else {
-          APNsRegistrationCoordinator.unregisterCurrentDevice(using: current())
-          deleteCookie()
-          ApiEnvironmentStore.shared.activateTenant(slug: nil)
-          completeRefresh(generation: generation, state: .signedOut)
-        }
-      } catch APIError.unauthorized {
-        APNsRegistrationCoordinator.unregisterCurrentDevice(using: current())
-        deleteCookie()
-        ApiEnvironmentStore.shared.activateTenant(slug: nil)
-        completeRefresh(generation: generation, state: .signedOut)
-      } catch APIError.cancelled {
-        return
-      } catch {
-        completeRefresh(generation: generation, state: .failed(error.localizedDescription))
-      }
-    }
-    lock.withLock {
-      if generation == refreshGeneration {
-        refreshTask = task
-      } else {
-        task.cancel()
-      }
-    }
+    startRefresh(joinInFlight: false)
   }
 
   func observe(
-    _ observer: @escaping @Sendable (AfilmorySessionState) -> Void
+    _ observer: @escaping AfilmorySessionObserver
   ) -> AfilmorySessionObservationToken {
     let id = UUID()
     let currentState = lock.withLock { () -> AfilmorySessionState in
@@ -160,52 +177,114 @@ final class AfilmorySessionStore: @unchecked Sendable {
   }
 
   func hasStoredCookie() -> Bool {
-    loadCookie() != nil
+    cookieStorage.read() != nil
   }
 
-  private func loadCookie() -> String? {
-    Self.readCookie()
+  @MainActor
+  private func publishCachedSession() {
+    guard cookieStorage.read() != nil,
+          let payload = repository.loadSession(),
+          let session = try? JSONDecoder().decode(AfilmorySession.self, from: payload)
+    else { return }
+    ApiEnvironmentStore.shared.activateTenant(slug: session.activeWorkspace?.slug)
+    publish(.signedIn(session))
   }
 
-  private static func readCookie() -> String? {
-    var query = Self.cookieQuery
-    query[kSecReturnData as String] = true
-    query[kSecMatchLimit as String] = kSecMatchLimitOne
+  private func startRefresh(joinInFlight: Bool) {
+    guard cookieStorage.read() != nil else {
+      publish(.signedOut)
+      return
+    }
 
-    var result: CFTypeRef?
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-          let data = result as? Data
-    else { return nil }
-    return String(data: data, encoding: .utf8)
-  }
-
-  private func deleteCookie() {
-    let status = SecItemDelete(Self.cookieQuery as CFDictionary)
-    if status != errSecSuccess, status != errSecItemNotFound {
-      NSLog("[AfilmorySessionStore] Unable to clear the session cookie: %d", status)
+    var enteredLoading = false
+    let started = lock.withLock { () -> Bool in
+      if refreshTask != nil {
+        guard !joinInFlight else { return false }
+        refreshTask?.cancel()
+      }
+      refreshGeneration &+= 1
+      if state.session == nil, state != .loading {
+        state = .loading
+        enteredLoading = true
+      }
+      let generation = refreshGeneration
+      refreshTask = Task { [weak self] in
+        await self?.performRefresh(generation: generation)
+      }
+      return true
+    }
+    guard started else { return }
+    if enteredLoading {
+      publishCurrent()
     }
   }
 
+  private func performRefresh(generation: UInt64) async {
+    do {
+      let response = try await transport.fetchSession()
+      guard !Task.isCancelled, isCurrentRefresh(generation) else { return }
+      guard let session = response?.resolved() else {
+        await applyServerSignOut(generation: generation)
+        return
+      }
+      ApiEnvironmentStore.shared.activateTenant(slug: session.activeWorkspace?.slug)
+      if let payload = try? JSONEncoder().encode(session) {
+        await repository.saveSession(payload)
+      }
+      completeRefresh(generation: generation, state: .signedIn(session))
+    } catch APIError.unauthorized {
+      await applyServerSignOut(generation: generation)
+    } catch APIError.cancelled {
+      return
+    } catch {
+      completeRefreshKeepingSession(generation: generation, error: error)
+    }
+  }
+
+  private func applyServerSignOut(generation: UInt64) async {
+    guard isCurrentRefresh(generation) else { return }
+    APNsRegistrationCoordinator.unregisterCurrentDevice(using: current())
+    cookieStorage.clear()
+    ApiEnvironmentStore.shared.activateTenant(slug: nil)
+    await repository.wipeAll()
+    completeRefresh(generation: generation, state: .signedOut)
+  }
+
+  private func isCurrentRefresh(_ generation: UInt64) -> Bool {
+    lock.withLock { generation == refreshGeneration }
+  }
+
   private func completeRefresh(generation: UInt64, state: AfilmorySessionState) {
-    let observers = lock.withLock { () -> [@Sendable (AfilmorySessionState) -> Void] in
-      guard generation == refreshGeneration else { return [] }
+    let observers = lock.withLock { () -> [AfilmorySessionObserver]? in
+      guard generation == refreshGeneration else { return nil }
       refreshTask = nil
       self.state = state
       return Array(self.observers.values)
     }
-    if let session = state.session {
-      ShareUploadContextStore.update(session: session)
-    } else if state == .signedOut {
-      ShareUploadContextStore.clear()
-    }
+    guard let observers else { return }
+    synchronizeUploadContext(state)
     notify(observers, state: state)
   }
 
+  private func completeRefreshKeepingSession(generation: UInt64, error: Error) {
+    NSLog("[AfilmorySessionStore] Session refresh failed: %@", error.localizedDescription)
+    let failure = lock.withLock { () -> (AfilmorySessionState, [AfilmorySessionObserver])? in
+      guard generation == refreshGeneration else { return nil }
+      refreshTask = nil
+      guard state.session == nil else { return nil }
+      state = .failed(error.localizedDescription)
+      return (state, Array(observers.values))
+    }
+    guard let failure else { return }
+    notify(failure.1, state: failure.0)
+  }
+
   private func publish(_ state: AfilmorySessionState) {
-    let observers = lock.withLock { () -> [@Sendable (AfilmorySessionState) -> Void] in
+    let observers = lock.withLock { () -> [AfilmorySessionObserver] in
       self.state = state
       return Array(self.observers.values)
     }
+    synchronizeUploadContext(state)
     notify(observers, state: state)
   }
 
@@ -214,21 +293,21 @@ final class AfilmorySessionStore: @unchecked Sendable {
     notify(snapshot.1, state: snapshot.0)
   }
 
+  private func synchronizeUploadContext(_ state: AfilmorySessionState) {
+    if let session = state.session {
+      ShareUploadContextStore.update(session: session)
+    } else if state == .signedOut {
+      ShareUploadContextStore.clear()
+    }
+  }
+
   private func notify(
-    _ observers: [@Sendable (AfilmorySessionState) -> Void],
+    _ observers: [AfilmorySessionObserver],
     state: AfilmorySessionState
   ) {
     for observer in observers {
       observer(state)
     }
-  }
-
-  private static var cookieQuery: [String: Any] {
-    [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: cookieService,
-      kSecAttrAccount as String: cookieAccount,
-    ]
   }
 
   private static func normalizedBaseURL(_ value: String) -> String? {

--- a/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Security
+import UIKit
 
 struct AfilmorySessionSnapshot: Sendable {
   let cookie: String?
@@ -85,6 +86,7 @@ final class AfilmorySessionStore: @unchecked Sendable {
   private var refreshTask: Task<Void, Never>?
   private var refreshGeneration: UInt64 = 0
   private var bootstrapped = false
+  private var foregroundObserver: NSObjectProtocol?
 
   init(
     repository: PhotoCacheRepository = SwiftDataPhotoCacheRepository(container: AfilmoryDatabase.shared),
@@ -97,6 +99,21 @@ final class AfilmorySessionStore: @unchecked Sendable {
     platformBaseURL = ApiEnvironmentStore.storedOrBuildDefault().platformAPIBaseURL().absoluteString
     tenantBaseURL = nil
     state = cookieStorage.read() == nil ? .signedOut : .loading
+    foregroundObserver = NotificationCenter.default.addObserver(
+      forName: UIApplication.didBecomeActiveNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        self?.bootstrap()
+      }
+    }
+  }
+
+  deinit {
+    if let foregroundObserver {
+      NotificationCenter.default.removeObserver(foregroundObserver)
+    }
   }
 
   func register(cookie: String) {
@@ -146,13 +163,17 @@ final class AfilmorySessionStore: @unchecked Sendable {
 
   @MainActor
   func bootstrap() {
-    let shouldStart = lock.withLock { () -> Bool in
+    let isFirstBootstrap = lock.withLock { () -> Bool in
       guard !bootstrapped else { return false }
       bootstrapped = true
       return true
     }
-    guard shouldStart else { return }
-    publishCachedSession()
+    if isFirstBootstrap {
+      publishCachedSession()
+    }
+    // Later bootstraps (foreground, tab mount) are the only retry hook an unresolved session gets.
+    let isUnresolved = lock.withLock { state.session == nil }
+    guard isFirstBootstrap || isUnresolved else { return }
     startRefresh(joinInFlight: true)
   }
 
@@ -192,7 +213,9 @@ final class AfilmorySessionStore: @unchecked Sendable {
 
   private func startRefresh(joinInFlight: Bool) {
     guard cookieStorage.read() != nil else {
-      publish(.signedOut)
+      if lock.withLock({ state != .signedOut }) {
+        publish(.signedOut)
+      }
       return
     }
 

--- a/apps/mobile/modules/photo-masonry/ios/Data/GalleryDirectoryStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Data/GalleryDirectoryStore.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftData
+
+protocol GalleryDirectoryTransport: Sendable {
+  func fetchGalleryDirectory(query: String, limit: Int) async throws -> FeaturedGalleriesEnvelope
+}
+
+struct LiveGalleryDirectoryTransport: GalleryDirectoryTransport {
+  func fetchGalleryDirectory(query: String, limit: Int) async throws -> FeaturedGalleriesEnvelope {
+    let endpoint = APIEndpoint(
+      baseURL: .platform,
+      path: "gallery-directory",
+      queryItems: [
+        query.isEmpty ? nil : URLQueryItem(name: "q", value: query),
+        URLQueryItem(name: "limit", value: String(limit)),
+      ].compactMap { $0 },
+      retryPolicy: .transientGET(maxAttempts: 2, delay: 0.25)
+    )
+    return try await AfilmoryAPI.shared.request(endpoint)
+  }
+}
+
+@MainActor
+final class GalleryDirectoryStore {
+  private let repository: PhotoCacheRepository
+  private let transport: GalleryDirectoryTransport
+
+  init(
+    repository: PhotoCacheRepository = SwiftDataPhotoCacheRepository(container: AfilmoryDatabase.shared),
+    transport: GalleryDirectoryTransport = LiveGalleryDirectoryTransport()
+  ) {
+    self.repository = repository
+    self.transport = transport
+  }
+
+  func loadCached() -> [FeaturedGallery]? {
+    guard let payload = repository.loadGalleryDirectory() else { return nil }
+    return try? JSONDecoder().decode(FeaturedGalleriesEnvelope.self, from: payload).galleries
+  }
+
+  func fetch(query: String, limit: Int) async throws -> [FeaturedGallery] {
+    let envelope = try await transport.fetchGalleryDirectory(query: query, limit: limit)
+    if let payload = try? JSONEncoder().encode(envelope) {
+      await repository.saveGalleryDirectory(payload)
+    }
+    return envelope.galleries
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Data/GalleryDirectoryStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Data/GalleryDirectoryStore.swift
@@ -40,7 +40,7 @@ final class GalleryDirectoryStore {
 
   func fetch(query: String, limit: Int) async throws -> [FeaturedGallery] {
     let envelope = try await transport.fetchGalleryDirectory(query: query, limit: limit)
-    if let payload = try? JSONEncoder().encode(envelope) {
+    if query.isEmpty, let payload = try? JSONEncoder().encode(envelope) {
       await repository.saveGalleryDirectory(payload)
     }
     return envelope.galleries

--- a/apps/mobile/modules/photo-masonry/ios/Data/PhotoFeedStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Data/PhotoFeedStore.swift
@@ -94,6 +94,7 @@ final class PhotoFeedStore {
   private let manifestTransport: ManifestTransport
   private var feeds: [PhotoFeedKey: PhotoFeed] = [:]
   private var loads: [PhotoFeedKey: Task<Void, Never>] = [:]
+  private var loadGenerations: [PhotoFeedKey: UUID] = [:]
 
   init(
     repository: PhotoCacheRepository = SwiftDataPhotoCacheRepository(container: AfilmoryDatabase.shared),
@@ -132,6 +133,9 @@ final class PhotoFeedStore {
       feed.update(photos: feed.photos, studioPhotos: feed.studioPhotos, state: .loading)
     }
 
+    let generation = UUID()
+    loadGenerations[key] = generation
+
     loads[key] = Task { [weak self, weak feed] in
       guard let self, let feed else { return }
       do {
@@ -169,7 +173,9 @@ final class PhotoFeedStore {
           )
         }
       }
+      guard self.loadGenerations[key] == generation else { return }
       self.loads[key] = nil
+      self.loadGenerations[key] = nil
     }
   }
 }

--- a/apps/mobile/modules/photo-masonry/ios/Data/PhotoFeedStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Data/PhotoFeedStore.swift
@@ -1,5 +1,24 @@
 import Foundation
 import Observation
+import SwiftData
+
+protocol ManifestTransport: Sendable {
+  func fetchManifest(slug: String, etag: String?) async throws -> ManifestFetchOutcome
+}
+
+struct LiveManifestTransport: ManifestTransport {
+  private let api: AfilmoryAPI
+
+  init(api: AfilmoryAPI = .shared) {
+    self.api = api
+  }
+
+  func fetchManifest(slug: String, etag: String?) async throws -> ManifestFetchOutcome {
+    let apiBaseURL = try ApiEnvironmentStore.shared.galleryAPIBaseURL(slug: slug)
+    let endpoint = APIEndpoint(baseURL: .explicit(apiBaseURL.absoluteString), path: "manifest")
+    return try await api.fetchManifest(endpoint, etag: etag)
+  }
+}
 
 enum PhotoFeedLoadState: Equatable, Sendable {
   case idle
@@ -71,8 +90,18 @@ final class PhotoFeedObservationToken {
 final class PhotoFeedStore {
   static let shared = PhotoFeedStore()
 
+  private let repository: PhotoCacheRepository
+  private let manifestTransport: ManifestTransport
   private var feeds: [PhotoFeedKey: PhotoFeed] = [:]
   private var loads: [PhotoFeedKey: Task<Void, Never>] = [:]
+
+  init(
+    repository: PhotoCacheRepository = SwiftDataPhotoCacheRepository(container: AfilmoryDatabase.shared),
+    manifestTransport: ManifestTransport = LiveManifestTransport()
+  ) {
+    self.repository = repository
+    self.manifestTransport = manifestTransport
+  }
 
   func feed(for key: PhotoFeedKey) -> PhotoFeed {
     if let feed = feeds[key] {
@@ -89,19 +118,37 @@ final class PhotoFeedStore {
       return
     }
     loads[key]?.cancel()
-    feed.update(photos: feed.photos, studioPhotos: feed.studioPhotos, state: .loading)
+
+    let cached: (photos: [GalleryPhoto], etag: String?)?
+    if case .manifest = key {
+      cached = repository.loadFeed(key)
+    } else {
+      cached = nil
+    }
+
+    if let cached {
+      feed.update(photos: cached.photos, state: .loaded)
+    } else {
+      feed.update(photos: feed.photos, studioPhotos: feed.studioPhotos, state: .loading)
+    }
+
     loads[key] = Task { [weak self, weak feed] in
       guard let self, let feed else { return }
       do {
         switch key {
         case .manifest(let slug):
           let origin = try ApiEnvironmentStore.shared.galleryOrigin(slug: slug)
-          let apiBaseURL = try ApiEnvironmentStore.shared.galleryAPIBaseURL(slug: slug)
-          let endpoint = APIEndpoint(baseURL: .explicit(apiBaseURL.absoluteString), path: "manifest")
-          let response: ManifestEnvelope = try await AfilmoryAPI.shared.request(endpoint)
-          let photos = ManifestDecoding.normalize(response.data, galleryOrigin: origin)
+          let outcome = try await self.manifestTransport.fetchManifest(slug: slug, etag: cached?.etag)
           guard !Task.isCancelled else { return }
-          feed.update(photos: photos, state: .loaded)
+          switch outcome {
+          case .notModified:
+            await self.repository.touchFeed(key)
+          case .success(let data, let etag):
+            let photos = try ManifestDecoding.decode(data, galleryOrigin: origin)
+            guard !Task.isCancelled else { return }
+            feed.update(photos: photos, state: .loaded)
+            await self.repository.saveFeed(key, photos: photos, etag: etag)
+          }
         case .studioLibrary:
           let endpoint = APIEndpoint(baseURL: .tenant, path: "photos/assets")
           let assets: [StudioAsset] = try await AfilmoryAPI.shared.request(endpoint)
@@ -111,12 +158,16 @@ final class PhotoFeedStore {
         }
       } catch {
         guard !Task.isCancelled else { return }
-        feed.update(
-          photos: feed.photos,
-          studioPhotos: feed.studioPhotos,
-          state: .failed,
-          error: error.localizedDescription
-        )
+        if cached != nil {
+          NSLog("[PhotoFeedStore] Manifest refresh failed for %@: %@", key.rawValue, error.localizedDescription)
+        } else {
+          feed.update(
+            photos: feed.photos,
+            studioPhotos: feed.studioPhotos,
+            state: .failed,
+            error: error.localizedDescription
+          )
+        }
       }
       self.loads[key] = nil
     }

--- a/apps/mobile/modules/photo-masonry/ios/Pages/GalleriesController.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Pages/GalleriesController.swift
@@ -2,12 +2,12 @@ import ExpoModulesCore
 import SDWebImage
 import UIKit
 
-struct FeaturedGalleryAuthor: Decodable, Hashable, Sendable {
+struct FeaturedGalleryAuthor: Codable, Hashable, Sendable {
   let name: String
   let avatar: String?
 }
 
-struct FeaturedGallery: Decodable, Hashable, Sendable {
+struct FeaturedGallery: Codable, Hashable, Sendable {
   let id: String
   let name: String
   let slug: String
@@ -30,7 +30,7 @@ struct GalleryCoverPhoto: Hashable, Sendable {
   let isLivePhoto: Bool
 }
 
-private struct FeaturedGalleriesEnvelope: Decodable, Sendable {
+struct FeaturedGalleriesEnvelope: Codable, Sendable {
   let galleries: [FeaturedGallery]
 }
 
@@ -60,6 +60,7 @@ final class GalleriesController: UIViewController {
   private let localization = Localization.shared
   private let onRequestSignIn: () -> Void
   private let notificationPermissions = GalleryNotificationPermissionCoordinator()
+  private let galleryDirectoryStore = GalleryDirectoryStore()
   private let layout = UICollectionViewFlowLayout()
   private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
   private let refreshControl = UIRefreshControl()
@@ -196,36 +197,20 @@ final class GalleriesController: UIViewController {
   private func loadGalleries(force: Bool = false) {
     if loadTask != nil, !force { return }
     loadTask?.cancel()
+    let requestedQuery = activeQuery
+    if requestedQuery.isEmpty, galleries.isEmpty, let cached = galleryDirectoryStore.loadCached() {
+      applyGalleries(cached)
+    }
     if galleries.isEmpty {
       contentUnavailableConfiguration = UIContentUnavailableConfiguration.loading()
     }
-    let requestedQuery = activeQuery
     loadTask = Task { @MainActor [weak self] in
       guard let self else { return }
       do {
-        let endpoint = APIEndpoint(
-          baseURL: .platform,
-          path: "gallery-directory",
-          queryItems: [
-            requestedQuery.isEmpty ? nil : URLQueryItem(name: "q", value: requestedQuery),
-            URLQueryItem(name: "limit", value: "30"),
-          ].compactMap { $0 },
-          retryPolicy: .transientGET(maxAttempts: 2, delay: 0.25)
-        )
-        let response: FeaturedGalleriesEnvelope = try await AfilmoryAPI.shared.request(endpoint)
+        let fetched = try await galleryDirectoryStore.fetch(query: requestedQuery, limit: 30)
         try Task.checkCancellation()
         guard requestedQuery == activeQuery else { return }
-        galleries = response.galleries.map { gallery in
-          guard let pendingTarget = self.pendingSubscriptionTargets[gallery.id] else {
-            return gallery
-          }
-          var gallery = gallery
-          gallery.isSubscribed = pendingTarget
-          return gallery
-        }
-        refreshNotificationPresentation()
-        contentUnavailableConfiguration = galleries.isEmpty ? emptyConfiguration() : nil
-        prefetchVisibleCovers()
+        applyGalleries(fetched)
       } catch {
         guard !Task.isCancelled else { return }
         if galleries.isEmpty {
@@ -235,6 +220,20 @@ final class GalleriesController: UIViewController {
       refreshControl.endRefreshing()
       loadTask = nil
     }
+  }
+
+  private func applyGalleries(_ fetched: [FeaturedGallery]) {
+    galleries = fetched.map { gallery in
+      guard let pendingTarget = pendingSubscriptionTargets[gallery.id] else {
+        return gallery
+      }
+      var gallery = gallery
+      gallery.isSubscribed = pendingTarget
+      return gallery
+    }
+    refreshNotificationPresentation()
+    contentUnavailableConfiguration = galleries.isEmpty ? emptyConfiguration() : nil
+    prefetchVisibleCovers()
   }
 
   private func loadCovers(for gallery: FeaturedGallery) {

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/AfilmoryDatabase.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/AfilmoryDatabase.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftData
+
+enum AfilmoryDatabase {
+  static let schema = Schema([
+    CachedPhoto.self,
+    CachedFeed.self,
+    CachedGalleryDirectory.self,
+    CachedSession.self,
+  ])
+
+  static let shared: ModelContainer = makeContainer(at: storeURL())
+
+  static func makeInMemoryContainer() -> ModelContainer {
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    return try! ModelContainer(for: schema, configurations: [configuration])
+  }
+
+  static func makeContainer(at url: URL) -> ModelContainer {
+    let configuration = ModelConfiguration(schema: schema, url: url)
+    if let container = try? ModelContainer(for: schema, configurations: [configuration]) {
+      return container
+    }
+    NSLog("[AfilmoryDatabase] Cache store failed to open, recreating: %@", url.path)
+    removeStoreFiles(at: url)
+    if let container = try? ModelContainer(for: schema, configurations: [configuration]) {
+      return container
+    }
+    NSLog("[AfilmoryDatabase] Cache store still unusable after recreation, falling back to in-memory: %@", url.path)
+    return makeInMemoryContainer()
+  }
+
+  static func storeURL(
+    in directory: URL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+  ) -> URL {
+    let folder = directory.appending(path: "AfilmoryCache", directoryHint: .isDirectory)
+    try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+    return folder.appending(path: "AfilmoryCache.store")
+  }
+
+  private static func removeStoreFiles(at url: URL) {
+    let fileManager = FileManager.default
+    for suffix in ["", "-wal", "-shm"] {
+      try? fileManager.removeItem(atPath: url.path + suffix)
+    }
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/CacheLifecycle.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/CacheLifecycle.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SDWebImage
+
+enum CacheLifecycle {
+  static let staleFeedCutoffInterval: TimeInterval = 60 * 60 * 24 * 30
+  static let imageCacheMaxDiskSize: UInt = 512 * 1024 * 1024
+  static let imageCacheMaxDiskAgeInterval: TimeInterval = 60 * 60 * 24 * 60
+}
+
+final class CacheLifecycleCoordinator: @unchecked Sendable {
+  static let shared = CacheLifecycleCoordinator()
+
+  private let lock = NSLock()
+  private var hasRun = false
+
+  func runOnce(
+    repository: PhotoCacheRepository = SwiftDataPhotoCacheRepository(container: AfilmoryDatabase.shared),
+    imageCache: SDImageCache = .shared,
+    now: Date = Date()
+  ) {
+    let shouldRun = lock.withLock { () -> Bool in
+      guard !hasRun else { return false }
+      hasRun = true
+      return true
+    }
+    guard shouldRun else { return }
+
+    imageCache.config.maxDiskSize = CacheLifecycle.imageCacheMaxDiskSize
+    imageCache.config.maxDiskAge = CacheLifecycle.imageCacheMaxDiskAgeInterval
+
+    let cutoff = now.addingTimeInterval(-CacheLifecycle.staleFeedCutoffInterval)
+    Task(priority: .background) {
+      await repository.pruneStale(olderThan: cutoff)
+    }
+  }
+}
+
+private extension NSLock {
+  func withLock<T>(_ body: () -> T) -> T {
+    lock()
+    defer { unlock() }
+    return body()
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/CacheModels.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/CacheModels.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedPhoto {
+  #Unique<CachedPhoto>([\.feedKey, \.photoId])
+  #Index<CachedPhoto>([\.feedKey])
+
+  var photoId: String
+  var feedKey: String
+  var orderIndex: Int
+  var takenAt: Date?
+  var payload: Data
+
+  init(photoId: String, feedKey: String, orderIndex: Int, takenAt: Date?, payload: Data) {
+    self.photoId = photoId
+    self.feedKey = feedKey
+    self.orderIndex = orderIndex
+    self.takenAt = takenAt
+    self.payload = payload
+  }
+}
+
+@Model
+final class CachedFeed {
+  #Unique<CachedFeed>([\.feedKey])
+
+  var feedKey: String
+  var etag: String?
+  var fetchedAt: Date
+  var photoCount: Int
+
+  init(feedKey: String, etag: String?, fetchedAt: Date, photoCount: Int) {
+    self.feedKey = feedKey
+    self.etag = etag
+    self.fetchedAt = fetchedAt
+    self.photoCount = photoCount
+  }
+}
+
+@Model
+final class CachedGalleryDirectory {
+  var payload: Data
+  var fetchedAt: Date
+
+  init(payload: Data, fetchedAt: Date) {
+    self.payload = payload
+    self.fetchedAt = fetchedAt
+  }
+}
+
+@Model
+final class CachedSession {
+  var payload: Data
+  var fetchedAt: Date
+
+  init(payload: Data, fetchedAt: Date) {
+    self.payload = payload
+    self.fetchedAt = fetchedAt
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/InMemoryPhotoCacheRepository.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/InMemoryPhotoCacheRepository.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+final class InMemoryPhotoCacheRepository: PhotoCacheRepository, @unchecked Sendable {
+  private struct FeedRecord {
+    var photos: [GalleryPhoto]
+    var etag: String?
+    var fetchedAt: Date
+  }
+
+  private let lock = NSLock()
+  private var feeds: [String: FeedRecord] = [:]
+  private var galleryDirectory: Data?
+  private var session: Data?
+
+  @MainActor
+  func loadFeed(_ key: PhotoFeedKey) -> (photos: [GalleryPhoto], etag: String?)? {
+    lock.withLock {
+      guard let record = feeds[key.rawValue] else { return nil }
+      return (record.photos, record.etag)
+    }
+  }
+
+  func saveFeed(_ key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?) async {
+    lock.withLock {
+      feeds[key.rawValue] = FeedRecord(photos: photos, etag: etag, fetchedAt: Date())
+    }
+  }
+
+  func touchFeed(_ key: PhotoFeedKey) async {
+    lock.withLock {
+      feeds[key.rawValue]?.fetchedAt = Date()
+    }
+  }
+
+  @MainActor
+  func loadGalleryDirectory() -> Data? {
+    lock.withLock { galleryDirectory }
+  }
+
+  func saveGalleryDirectory(_ payload: Data) async {
+    lock.withLock { galleryDirectory = payload }
+  }
+
+  @MainActor
+  func loadSession() -> Data? {
+    lock.withLock { session }
+  }
+
+  func saveSession(_ payload: Data) async {
+    lock.withLock { session = payload }
+  }
+
+  func clearSession() async {
+    lock.withLock { session = nil }
+  }
+
+  func wipeAll() async {
+    lock.withLock {
+      feeds.removeAll()
+      galleryDirectory = nil
+      session = nil
+    }
+  }
+
+  func pruneStale(olderThan cutoff: Date) async {
+    lock.withLock {
+      feeds = feeds.filter { $0.value.fetchedAt >= cutoff }
+    }
+  }
+}
+
+private extension NSLock {
+  func withLock<T>(_ body: () -> T) -> T {
+    lock()
+    defer { unlock() }
+    return body()
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/PhotoCacheRepository.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/PhotoCacheRepository.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+protocol PhotoCacheRepository: Sendable {
+  @MainActor func loadFeed(_ key: PhotoFeedKey) -> (photos: [GalleryPhoto], etag: String?)?
+  func saveFeed(_ key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?) async
+  func touchFeed(_ key: PhotoFeedKey) async
+
+  @MainActor func loadGalleryDirectory() -> Data?
+  func saveGalleryDirectory(_ payload: Data) async
+
+  @MainActor func loadSession() -> Data?
+  func saveSession(_ payload: Data) async
+  func clearSession() async
+
+  func wipeAll() async
+  func pruneStale(olderThan cutoff: Date) async
+}

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/SwiftDataPhotoCacheRepository.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/SwiftDataPhotoCacheRepository.swift
@@ -36,9 +36,10 @@ final class SwiftDataPhotoCacheRepository: PhotoCacheRepository, Sendable {
       }
     }
 
-    if !corruptedPhotoIds.isEmpty {
+    guard corruptedPhotoIds.isEmpty else {
       let mutator = mutator
       Task { await mutator.deleteCorruptedPhotos(feedKey: feedKey, photoIds: corruptedPhotoIds) }
+      return photos.isEmpty ? nil : (photos, nil)
     }
 
     return (photos, feed.etag)

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/SwiftDataPhotoCacheRepository.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/SwiftDataPhotoCacheRepository.swift
@@ -1,0 +1,199 @@
+import Foundation
+import SwiftData
+
+final class SwiftDataPhotoCacheRepository: PhotoCacheRepository, Sendable {
+  private let container: ModelContainer
+  private let mutator: PhotoCacheMutator
+
+  init(container: ModelContainer) {
+    self.container = container
+    mutator = PhotoCacheMutator(modelContainer: container)
+  }
+
+  @MainActor
+  func loadFeed(_ key: PhotoFeedKey) -> (photos: [GalleryPhoto], etag: String?)? {
+    let feedKey = key.rawValue
+    let context = container.mainContext
+
+    let feedDescriptor = FetchDescriptor<CachedFeed>(predicate: #Predicate<CachedFeed> { $0.feedKey == feedKey })
+    guard let feed = try? context.fetch(feedDescriptor).first else { return nil }
+
+    let photoDescriptor = FetchDescriptor<CachedPhoto>(
+      predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey },
+      sortBy: [SortDescriptor(\.orderIndex)]
+    )
+    let rows = (try? context.fetch(photoDescriptor)) ?? []
+
+    let decoder = JSONDecoder()
+    var photos: [GalleryPhoto] = []
+    photos.reserveCapacity(rows.count)
+    var corruptedRows: [CachedPhoto] = []
+    for row in rows {
+      if let photo = try? decoder.decode(GalleryPhoto.self, from: row.payload) {
+        photos.append(photo)
+      } else {
+        corruptedRows.append(row)
+      }
+    }
+
+    if !corruptedRows.isEmpty {
+      for row in corruptedRows {
+        context.delete(row)
+      }
+      try? context.save()
+    }
+
+    return (photos, feed.etag)
+  }
+
+  func saveFeed(_ key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?) async {
+    await mutator.saveFeed(feedKey: key.rawValue, photos: photos, etag: etag)
+  }
+
+  func touchFeed(_ key: PhotoFeedKey) async {
+    await mutator.touchFeed(feedKey: key.rawValue)
+  }
+
+  @MainActor
+  func loadGalleryDirectory() -> Data? {
+    let context = container.mainContext
+    return (try? context.fetch(FetchDescriptor<CachedGalleryDirectory>()))?.first?.payload
+  }
+
+  func saveGalleryDirectory(_ payload: Data) async {
+    await mutator.saveGalleryDirectory(payload: payload)
+  }
+
+  @MainActor
+  func loadSession() -> Data? {
+    let context = container.mainContext
+    return (try? context.fetch(FetchDescriptor<CachedSession>()))?.first?.payload
+  }
+
+  func saveSession(_ payload: Data) async {
+    await mutator.saveSession(payload: payload)
+  }
+
+  func clearSession() async {
+    await mutator.clearSession()
+  }
+
+  func wipeAll() async {
+    await mutator.wipeAll()
+  }
+
+  func pruneStale(olderThan cutoff: Date) async {
+    await mutator.pruneStale(olderThan: cutoff)
+  }
+}
+
+@ModelActor
+private actor PhotoCacheMutator {
+  func saveFeed(feedKey: String, photos: [GalleryPhoto], etag: String?) {
+    let existingDescriptor = FetchDescriptor<CachedPhoto>(predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey })
+    var rowsByPhotoId = Dictionary(
+      uniqueKeysWithValues: ((try? modelContext.fetch(existingDescriptor)) ?? []).map { ($0.photoId, $0) }
+    )
+
+    let encoder = JSONEncoder()
+    var orderIndex = 0
+    for photo in photos {
+      guard let payload = try? encoder.encode(photo) else { continue }
+      let takenAt = photo.dateTaken.flatMap { PhotoDateParser.date($0) }
+      if let row = rowsByPhotoId.removeValue(forKey: photo.id) {
+        row.orderIndex = orderIndex
+        row.takenAt = takenAt
+        row.payload = payload
+      } else {
+        modelContext.insert(
+          CachedPhoto(photoId: photo.id, feedKey: feedKey, orderIndex: orderIndex, takenAt: takenAt, payload: payload)
+        )
+      }
+      orderIndex += 1
+    }
+
+    for orphan in rowsByPhotoId.values {
+      modelContext.delete(orphan)
+    }
+
+    let feedDescriptor = FetchDescriptor<CachedFeed>(predicate: #Predicate<CachedFeed> { $0.feedKey == feedKey })
+    if let feed = try? modelContext.fetch(feedDescriptor).first {
+      feed.etag = etag
+      feed.fetchedAt = Date()
+      feed.photoCount = orderIndex
+    } else {
+      modelContext.insert(CachedFeed(feedKey: feedKey, etag: etag, fetchedAt: Date(), photoCount: orderIndex))
+    }
+
+    try? modelContext.save()
+  }
+
+  func touchFeed(feedKey: String) {
+    let descriptor = FetchDescriptor<CachedFeed>(predicate: #Predicate<CachedFeed> { $0.feedKey == feedKey })
+    guard let feed = try? modelContext.fetch(descriptor).first else { return }
+    feed.fetchedAt = Date()
+    try? modelContext.save()
+  }
+
+  func saveGalleryDirectory(payload: Data) {
+    let rows = (try? modelContext.fetch(FetchDescriptor<CachedGalleryDirectory>())) ?? []
+    if let first = rows.first {
+      first.payload = payload
+      first.fetchedAt = Date()
+      for extra in rows.dropFirst() {
+        modelContext.delete(extra)
+      }
+    } else {
+      modelContext.insert(CachedGalleryDirectory(payload: payload, fetchedAt: Date()))
+    }
+    try? modelContext.save()
+  }
+
+  func saveSession(payload: Data) {
+    let rows = (try? modelContext.fetch(FetchDescriptor<CachedSession>())) ?? []
+    if let first = rows.first {
+      first.payload = payload
+      first.fetchedAt = Date()
+      for extra in rows.dropFirst() {
+        modelContext.delete(extra)
+      }
+    } else {
+      modelContext.insert(CachedSession(payload: payload, fetchedAt: Date()))
+    }
+    try? modelContext.save()
+  }
+
+  func clearSession() {
+    deleteAll(CachedSession.self)
+    try? modelContext.save()
+  }
+
+  func wipeAll() {
+    deleteAll(CachedPhoto.self)
+    deleteAll(CachedFeed.self)
+    deleteAll(CachedGalleryDirectory.self)
+    deleteAll(CachedSession.self)
+    try? modelContext.save()
+  }
+
+  func pruneStale(olderThan cutoff: Date) {
+    let staleDescriptor = FetchDescriptor<CachedFeed>(predicate: #Predicate<CachedFeed> { $0.fetchedAt < cutoff })
+    let staleFeeds = (try? modelContext.fetch(staleDescriptor)) ?? []
+    for feed in staleFeeds {
+      let feedKey = feed.feedKey
+      let photoDescriptor = FetchDescriptor<CachedPhoto>(predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey })
+      for row in (try? modelContext.fetch(photoDescriptor)) ?? [] {
+        modelContext.delete(row)
+      }
+      modelContext.delete(feed)
+    }
+    try? modelContext.save()
+  }
+
+  private func deleteAll<T: PersistentModel>(_ type: T.Type) {
+    guard let rows = try? modelContext.fetch(FetchDescriptor<T>()) else { return }
+    for row in rows {
+      modelContext.delete(row)
+    }
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Persistence/SwiftDataPhotoCacheRepository.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Persistence/SwiftDataPhotoCacheRepository.swift
@@ -27,20 +27,18 @@ final class SwiftDataPhotoCacheRepository: PhotoCacheRepository, Sendable {
     let decoder = JSONDecoder()
     var photos: [GalleryPhoto] = []
     photos.reserveCapacity(rows.count)
-    var corruptedRows: [CachedPhoto] = []
+    var corruptedPhotoIds: [String] = []
     for row in rows {
       if let photo = try? decoder.decode(GalleryPhoto.self, from: row.payload) {
         photos.append(photo)
       } else {
-        corruptedRows.append(row)
+        corruptedPhotoIds.append(row.photoId)
       }
     }
 
-    if !corruptedRows.isEmpty {
-      for row in corruptedRows {
-        context.delete(row)
-      }
-      try? context.save()
+    if !corruptedPhotoIds.isEmpty {
+      let mutator = mutator
+      Task { await mutator.deleteCorruptedPhotos(feedKey: feedKey, photoIds: corruptedPhotoIds) }
     }
 
     return (photos, feed.etag)
@@ -125,6 +123,16 @@ private actor PhotoCacheMutator {
       modelContext.insert(CachedFeed(feedKey: feedKey, etag: etag, fetchedAt: Date(), photoCount: orderIndex))
     }
 
+    try? modelContext.save()
+  }
+
+  func deleteCorruptedPhotos(feedKey: String, photoIds: [String]) {
+    let idSet = Set(photoIds)
+    let descriptor = FetchDescriptor<CachedPhoto>(predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey })
+    let rows = (try? modelContext.fetch(descriptor)) ?? []
+    for row in rows where idSet.contains(row.photoId) {
+      modelContext.delete(row)
+    }
     try? modelContext.save()
   }
 

--- a/apps/mobile/modules/photo-masonry/ios/PhotoMasonry.podspec
+++ b/apps/mobile/modules/photo-masonry/ios/PhotoMasonry.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'SDWebImage', '~> 5.0'
-  s.frameworks = 'ActivityKit', 'AVFoundation', 'MapKit', 'StoreKit', 'Photos', 'PhotosUI', 'Security', 'UniformTypeIdentifiers', 'UserNotifications'
+  s.frameworks = 'ActivityKit', 'AVFoundation', 'MapKit', 'StoreKit', 'Photos', 'PhotosUI', 'Security', 'SwiftData', 'UniformTypeIdentifiers', 'UserNotifications'
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES'

--- a/apps/mobile/modules/photo-masonry/ios/Tests/CacheLifecycleTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/CacheLifecycleTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import PhotoMasonry
+
+final class CacheLifecycleTests: XCTestCase {
+  func testRunOnceCallsPruneStaleExactlyOnce() async throws {
+    let repository = SpyCacheRepository()
+    let coordinator = CacheLifecycleCoordinator()
+
+    coordinator.runOnce(repository: repository)
+    coordinator.runOnce(repository: repository)
+    coordinator.runOnce(repository: repository)
+
+    try await waitUntil { repository.pruneCalls.count == 1 }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    XCTAssertEqual(repository.pruneCalls.count, 1)
+  }
+
+  func testRunOncePrunesAThirtyDayCutoff() async throws {
+    let repository = SpyCacheRepository()
+    let coordinator = CacheLifecycleCoordinator()
+    let now = Date()
+
+    coordinator.runOnce(repository: repository, now: now)
+
+    try await waitUntil { repository.pruneCalls.count == 1 }
+
+    let cutoff = try XCTUnwrap(repository.pruneCalls.first)
+    let expected = now.addingTimeInterval(-60 * 60 * 24 * 30)
+    XCTAssertEqual(cutoff.timeIntervalSince1970, expected.timeIntervalSince1970, accuracy: 0.001)
+  }
+
+  private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () -> Bool
+  ) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition() {
+      if Date() >= deadline {
+        XCTFail("Timed out waiting for condition")
+        return
+      }
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+  }
+}
+
+private final class SpyCacheRepository: PhotoCacheRepository, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _pruneCalls: [Date] = []
+
+  var pruneCalls: [Date] {
+    lock.withLock { _pruneCalls }
+  }
+
+  @MainActor func loadFeed(_ key: PhotoFeedKey) -> (photos: [GalleryPhoto], etag: String?)? { nil }
+  func saveFeed(_ key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?) async {}
+  func touchFeed(_ key: PhotoFeedKey) async {}
+
+  @MainActor func loadGalleryDirectory() -> Data? { nil }
+  func saveGalleryDirectory(_ payload: Data) async {}
+
+  @MainActor func loadSession() -> Data? { nil }
+  func saveSession(_ payload: Data) async {}
+  func clearSession() async {}
+
+  func wipeAll() async {}
+
+  func pruneStale(olderThan cutoff: Date) async {
+    lock.withLock { _pruneCalls.append(cutoff) }
+  }
+}
+
+private extension NSLock {
+  func withLock<T>(_ body: () -> T) -> T {
+    lock()
+    defer { unlock() }
+    return body()
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Tests/GalleryDirectoryStoreCacheTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/GalleryDirectoryStoreCacheTests.swift
@@ -29,6 +29,19 @@ final class GalleryDirectoryStoreCacheTests: XCTestCase {
     XCTAssertEqual(store.loadCached()?.map(\.id), ["fresh"])
   }
 
+  func testFetchWithNonEmptyQueryDoesNotPersistToCache() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    await repository.saveGalleryDirectory(try Self.encode([Self.makeGallery(id: "cached")]))
+
+    let transport = FakeGalleryDirectoryTransport(steps: [.success([Self.makeGallery(id: "search-result")])])
+    let store = GalleryDirectoryStore(repository: repository, transport: transport)
+
+    let fetched = try await store.fetch(query: "sunset", limit: 30)
+
+    XCTAssertEqual(fetched.map(\.id), ["search-result"])
+    XCTAssertEqual(store.loadCached()?.map(\.id), ["cached"])
+  }
+
   func testFetchFailureLeavesTheCachedPayloadInPlace() async throws {
     let repository = InMemoryPhotoCacheRepository()
     await repository.saveGalleryDirectory(try Self.encode([Self.makeGallery(id: "cached")]))

--- a/apps/mobile/modules/photo-masonry/ios/Tests/GalleryDirectoryStoreCacheTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/GalleryDirectoryStoreCacheTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import PhotoMasonry
+
+@MainActor
+final class GalleryDirectoryStoreCacheTests: XCTestCase {
+  func testCachedDirectoryRendersBeforeNetworkResponds() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cached = [Self.makeGallery(id: "cached-a")]
+    await repository.saveGalleryDirectory(try Self.encode(cached))
+
+    let transport = FakeGalleryDirectoryTransport(steps: [.success([Self.makeGallery(id: "fresh-a")])])
+    let store = GalleryDirectoryStore(repository: repository, transport: transport)
+
+    XCTAssertEqual(store.loadCached()?.map(\.id), ["cached-a"])
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 0)
+  }
+
+  func testFetchOverwritesTheCachedPayloadOnSuccess() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    await repository.saveGalleryDirectory(try Self.encode([Self.makeGallery(id: "stale")]))
+
+    let transport = FakeGalleryDirectoryTransport(steps: [.success([Self.makeGallery(id: "fresh")])])
+    let store = GalleryDirectoryStore(repository: repository, transport: transport)
+
+    let fetched = try await store.fetch(query: "", limit: 30)
+
+    XCTAssertEqual(fetched.map(\.id), ["fresh"])
+    XCTAssertEqual(store.loadCached()?.map(\.id), ["fresh"])
+  }
+
+  func testFetchFailureLeavesTheCachedPayloadInPlace() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    await repository.saveGalleryDirectory(try Self.encode([Self.makeGallery(id: "cached")]))
+
+    let transport = FakeGalleryDirectoryTransport(steps: [.failure(APIError.http(status: 500, body: nil))])
+    let store = GalleryDirectoryStore(repository: repository, transport: transport)
+
+    do {
+      _ = try await store.fetch(query: "", limit: 30)
+      XCTFail("Expected the fetch to throw")
+    } catch {}
+
+    XCTAssertEqual(store.loadCached()?.map(\.id), ["cached"])
+  }
+
+  func testCorruptedCachedPayloadIsIgnored() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    await repository.saveGalleryDirectory(Data("not-json".utf8))
+
+    let transport = FakeGalleryDirectoryTransport(steps: [])
+    let store = GalleryDirectoryStore(repository: repository, transport: transport)
+
+    XCTAssertNil(store.loadCached())
+  }
+
+  private static func makeGallery(id: String) -> FeaturedGallery {
+    FeaturedGallery(
+      id: id,
+      name: id,
+      slug: id,
+      domain: nil,
+      description: nil,
+      author: nil,
+      photoCount: 0,
+      isSubscribed: false,
+      isOwnGallery: false,
+      tags: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUpload: nil
+    )
+  }
+
+  private static func encode(_ galleries: [FeaturedGallery]) throws -> Data {
+    try JSONEncoder().encode(FeaturedGalleriesEnvelope(galleries: galleries))
+  }
+}
+
+private actor FakeGalleryDirectoryTransport: GalleryDirectoryTransport {
+  enum Step {
+    case success([FeaturedGallery])
+    case failure(Error)
+  }
+
+  private var steps: [Step]
+  private(set) var requestCount = 0
+
+  init(steps: [Step]) {
+    self.steps = steps
+  }
+
+  func fetchGalleryDirectory(query: String, limit: Int) async throws -> FeaturedGalleriesEnvelope {
+    requestCount += 1
+    guard !steps.isEmpty else { throw APIError.cancelled }
+    switch steps.removeFirst() {
+    case .success(let galleries):
+      return FeaturedGalleriesEnvelope(galleries: galleries)
+    case .failure(let error):
+      throw error
+    }
+  }
+}
+
+private func XCTAssertThrowsErrorAsync(
+  _ expression: @autoclosure () async throws -> some Any,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async {
+  do {
+    _ = try await expression()
+    XCTFail("Expected an error to be thrown", file: file, line: line)
+  } catch {}
+}

--- a/apps/mobile/modules/photo-masonry/ios/Tests/PhotoCacheRepositoryTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/PhotoCacheRepositoryTests.swift
@@ -78,10 +78,27 @@ final class PhotoCacheRepositoryTests: XCTestCase {
 
     let loaded = await repository.loadFeed(key)
     XCTAssertEqual(loaded?.photos.map(\.id), ["a"])
-    XCTAssertEqual(loaded?.etag, "etag-1")
+    XCTAssertNil(loaded?.etag)
 
     let remainingRows = try await waitForPhotoRows(feedKey: key.rawValue, toMatch: ["a"])
     XCTAssertEqual(remainingRows.map(\.photoId), ["a"])
+  }
+
+  func testLoadFeedReturnsNilWhenAllPayloadRowsAreCorrupted() async throws {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(
+      key,
+      photos: [NativeFixtureTestSupport.photo(id: "a"), NativeFixtureTestSupport.photo(id: "b")],
+      etag: "etag-1"
+    )
+    try await corruptPayload(photoId: "a", feedKey: key.rawValue)
+    try await corruptPayload(photoId: "b", feedKey: key.rawValue)
+
+    let loaded = await repository.loadFeed(key)
+    XCTAssertNil(loaded)
+
+    let remainingRows = try await waitForPhotoRows(feedKey: key.rawValue, toMatch: [])
+    XCTAssertTrue(remainingRows.isEmpty)
   }
 
   func testTouchFeedUpdatesFetchedAtWithoutChangingPhotosOrEtag() async throws {

--- a/apps/mobile/modules/photo-masonry/ios/Tests/PhotoCacheRepositoryTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/PhotoCacheRepositoryTests.swift
@@ -80,7 +80,7 @@ final class PhotoCacheRepositoryTests: XCTestCase {
     XCTAssertEqual(loaded?.photos.map(\.id), ["a"])
     XCTAssertEqual(loaded?.etag, "etag-1")
 
-    let remainingRows = try await fetchPhotoRows(feedKey: key.rawValue)
+    let remainingRows = try await waitForPhotoRows(feedKey: key.rawValue, toMatch: ["a"])
     XCTAssertEqual(remainingRows.map(\.photoId), ["a"])
   }
 
@@ -170,6 +170,24 @@ final class PhotoCacheRepositoryTests: XCTestCase {
   private func fetchPhotoRows(feedKey: String) throws -> [CachedPhoto] {
     let descriptor = FetchDescriptor<CachedPhoto>(predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey })
     return try container.mainContext.fetch(descriptor)
+  }
+
+  private func waitForPhotoRows(
+    feedKey: String,
+    toMatch expectedPhotoIds: [String],
+    timeout: TimeInterval = 2
+  ) async throws -> [CachedPhoto] {
+    let deadline = Date().addingTimeInterval(timeout)
+    while true {
+      let rows = try await fetchPhotoRows(feedKey: feedKey)
+      if rows.map(\.photoId).sorted() == expectedPhotoIds.sorted() {
+        return rows
+      }
+      if Date() >= deadline {
+        return rows
+      }
+      try await Task.sleep(nanoseconds: 20_000_000)
+    }
   }
 
   @MainActor

--- a/apps/mobile/modules/photo-masonry/ios/Tests/PhotoCacheRepositoryTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/PhotoCacheRepositoryTests.swift
@@ -1,0 +1,274 @@
+import SwiftData
+import XCTest
+@testable import PhotoMasonry
+
+final class PhotoCacheRepositoryTests: XCTestCase {
+  private var container: ModelContainer!
+  private var repository: SwiftDataPhotoCacheRepository!
+
+  override func setUp() {
+    super.setUp()
+    container = AfilmoryDatabase.makeInMemoryContainer()
+    repository = SwiftDataPhotoCacheRepository(container: container)
+  }
+
+  override func tearDown() {
+    repository = nil
+    container = nil
+    super.tearDown()
+  }
+
+  func testFeedRoundTripPreservesOrderAndEtag() async {
+    let key = PhotoFeedKey.manifest("acme")
+    let photos = [
+      NativeFixtureTestSupport.photo(id: "a"),
+      NativeFixtureTestSupport.photo(id: "b"),
+      NativeFixtureTestSupport.photo(id: "c"),
+    ]
+
+    await repository.saveFeed(key, photos: photos, etag: "etag-1")
+
+    let loaded = await repository.loadFeed(key)
+    XCTAssertEqual(loaded?.photos.map(\.id), ["a", "b", "c"])
+    XCTAssertEqual(loaded?.etag, "etag-1")
+  }
+
+  func testLoadFeedReturnsNilWhenNeverSaved() async {
+    let loaded = await repository.loadFeed(.manifest("missing"))
+    XCTAssertNil(loaded)
+  }
+
+  func testSaveFeedUpsertsChangedPayloadsAndDeletesMissingPhotos() async throws {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(
+      key,
+      photos: [
+        NativeFixtureTestSupport.photo(id: "a", title: "Original"),
+        NativeFixtureTestSupport.photo(id: "b"),
+      ],
+      etag: "etag-1"
+    )
+
+    await repository.saveFeed(
+      key,
+      photos: [
+        NativeFixtureTestSupport.photo(id: "a", title: "Updated"),
+        NativeFixtureTestSupport.photo(id: "c"),
+      ],
+      etag: "etag-2"
+    )
+
+    let loaded = await repository.loadFeed(key)
+    XCTAssertEqual(loaded?.photos.map(\.id), ["a", "c"])
+    XCTAssertEqual(loaded?.photos.first?.title, "Updated")
+    XCTAssertEqual(loaded?.etag, "etag-2")
+
+    let remainingRows = try await fetchPhotoRows(feedKey: key.rawValue)
+    XCTAssertEqual(remainingRows.count, 2)
+  }
+
+  func testLoadFeedDropsAndDeletesCorruptedPayloadRow() async throws {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(
+      key,
+      photos: [NativeFixtureTestSupport.photo(id: "a"), NativeFixtureTestSupport.photo(id: "b")],
+      etag: "etag-1"
+    )
+    try await corruptPayload(photoId: "b", feedKey: key.rawValue)
+
+    let loaded = await repository.loadFeed(key)
+    XCTAssertEqual(loaded?.photos.map(\.id), ["a"])
+    XCTAssertEqual(loaded?.etag, "etag-1")
+
+    let remainingRows = try await fetchPhotoRows(feedKey: key.rawValue)
+    XCTAssertEqual(remainingRows.map(\.photoId), ["a"])
+  }
+
+  func testTouchFeedUpdatesFetchedAtWithoutChangingPhotosOrEtag() async throws {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(key, photos: [NativeFixtureTestSupport.photo(id: "a")], etag: "etag-1")
+    let backdated = Date(timeIntervalSinceNow: -1000)
+    try await backdateFeed(feedKey: key.rawValue, to: backdated)
+
+    await repository.touchFeed(key)
+
+    let updatedFetchedAt = try await feedFetchedAt(feedKey: key.rawValue)
+    XCTAssertNotNil(updatedFetchedAt)
+    XCTAssertGreaterThan(updatedFetchedAt!, backdated)
+
+    let loaded = await repository.loadFeed(key)
+    XCTAssertEqual(loaded?.etag, "etag-1")
+    XCTAssertEqual(loaded?.photos.map(\.id), ["a"])
+  }
+
+  func testPruneStaleRemovesOnlyStaleFeedsAndTheirPhotos() async throws {
+    let freshKey = PhotoFeedKey.manifest("fresh")
+    let staleKey = PhotoFeedKey.manifest("stale")
+
+    await repository.saveFeed(freshKey, photos: [NativeFixtureTestSupport.photo(id: "fresh-1")], etag: nil)
+    await repository.saveFeed(staleKey, photos: [NativeFixtureTestSupport.photo(id: "stale-1")], etag: nil)
+    try await backdateFeed(feedKey: staleKey.rawValue, to: Date(timeIntervalSinceNow: -60 * 60 * 24 * 40))
+
+    await repository.pruneStale(olderThan: Date(timeIntervalSinceNow: -60 * 60 * 24 * 30))
+
+    let freshLoaded = await repository.loadFeed(freshKey)
+    let staleLoaded = await repository.loadFeed(staleKey)
+    XCTAssertNotNil(freshLoaded)
+    XCTAssertNil(staleLoaded)
+    let remainingStaleRows = try await fetchPhotoRows(feedKey: staleKey.rawValue)
+    XCTAssertTrue(remainingStaleRows.isEmpty)
+  }
+
+  func testWipeAllEmptiesFeedsDirectoryAndSession() async throws {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(key, photos: [NativeFixtureTestSupport.photo(id: "a")], etag: "etag-1")
+    await repository.saveGalleryDirectory(Data("directory".utf8))
+    await repository.saveSession(Data("session".utf8))
+
+    await repository.wipeAll()
+
+    let loadedFeed = await repository.loadFeed(key)
+    let loadedDirectory = await repository.loadGalleryDirectory()
+    let loadedSession = await repository.loadSession()
+    XCTAssertNil(loadedFeed)
+    XCTAssertNil(loadedDirectory)
+    XCTAssertNil(loadedSession)
+    let remainingRows = try await fetchPhotoRows(feedKey: key.rawValue)
+    XCTAssertTrue(remainingRows.isEmpty)
+  }
+
+  func testGalleryDirectoryRoundTrip() async {
+    let initial = await repository.loadGalleryDirectory()
+    XCTAssertNil(initial)
+
+    let payload = Data("directory-payload".utf8)
+    await repository.saveGalleryDirectory(payload)
+    let loaded = await repository.loadGalleryDirectory()
+    XCTAssertEqual(loaded, payload)
+
+    let updated = Data("updated-directory-payload".utf8)
+    await repository.saveGalleryDirectory(updated)
+    let reloaded = await repository.loadGalleryDirectory()
+    XCTAssertEqual(reloaded, updated)
+  }
+
+  func testSessionRoundTripAndClear() async {
+    let initial = await repository.loadSession()
+    XCTAssertNil(initial)
+
+    let payload = Data("session-payload".utf8)
+    await repository.saveSession(payload)
+    let loaded = await repository.loadSession()
+    XCTAssertEqual(loaded, payload)
+
+    await repository.clearSession()
+    let cleared = await repository.loadSession()
+    XCTAssertNil(cleared)
+  }
+
+  @MainActor
+  private func fetchPhotoRows(feedKey: String) throws -> [CachedPhoto] {
+    let descriptor = FetchDescriptor<CachedPhoto>(predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey })
+    return try container.mainContext.fetch(descriptor)
+  }
+
+  @MainActor
+  private func feedFetchedAt(feedKey: String) throws -> Date? {
+    let descriptor = FetchDescriptor<CachedFeed>(predicate: #Predicate<CachedFeed> { $0.feedKey == feedKey })
+    return try container.mainContext.fetch(descriptor).first?.fetchedAt
+  }
+
+  @MainActor
+  private func backdateFeed(feedKey: String, to date: Date) throws {
+    let descriptor = FetchDescriptor<CachedFeed>(predicate: #Predicate<CachedFeed> { $0.feedKey == feedKey })
+    guard let feed = try container.mainContext.fetch(descriptor).first else {
+      XCTFail("expected a CachedFeed row for \(feedKey)")
+      return
+    }
+    feed.fetchedAt = date
+    try container.mainContext.save()
+  }
+
+  @MainActor
+  private func corruptPayload(photoId: String, feedKey: String) throws {
+    let descriptor = FetchDescriptor<CachedPhoto>(
+      predicate: #Predicate<CachedPhoto> { $0.feedKey == feedKey && $0.photoId == photoId }
+    )
+    guard let row = try container.mainContext.fetch(descriptor).first else {
+      XCTFail("expected a CachedPhoto row for \(photoId)")
+      return
+    }
+    row.payload = Data("not-json".utf8)
+    try container.mainContext.save()
+  }
+}
+
+final class InMemoryPhotoCacheRepositoryTests: XCTestCase {
+  private var repository: InMemoryPhotoCacheRepository!
+
+  override func setUp() {
+    super.setUp()
+    repository = InMemoryPhotoCacheRepository()
+  }
+
+  override func tearDown() {
+    repository = nil
+    super.tearDown()
+  }
+
+  func testFeedRoundTripAndUpsert() async {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(
+      key,
+      photos: [NativeFixtureTestSupport.photo(id: "a"), NativeFixtureTestSupport.photo(id: "b")],
+      etag: "etag-1"
+    )
+    let loaded = await repository.loadFeed(key)
+    XCTAssertEqual(loaded?.photos.map(\.id), ["a", "b"])
+    XCTAssertEqual(loaded?.etag, "etag-1")
+
+    await repository.saveFeed(key, photos: [NativeFixtureTestSupport.photo(id: "c")], etag: "etag-2")
+    let updated = await repository.loadFeed(key)
+    XCTAssertEqual(updated?.photos.map(\.id), ["c"])
+    XCTAssertEqual(updated?.etag, "etag-2")
+  }
+
+  func testWipeAllAndSessionDirectoryRoundTrip() async {
+    let key = PhotoFeedKey.manifest("acme")
+    await repository.saveFeed(key, photos: [NativeFixtureTestSupport.photo(id: "a")], etag: "etag-1")
+    await repository.saveGalleryDirectory(Data("directory".utf8))
+    await repository.saveSession(Data("session".utf8))
+
+    let loadedDirectory = await repository.loadGalleryDirectory()
+    let loadedSession = await repository.loadSession()
+    XCTAssertEqual(loadedDirectory, Data("directory".utf8))
+    XCTAssertEqual(loadedSession, Data("session".utf8))
+
+    await repository.wipeAll()
+
+    let wipedFeed = await repository.loadFeed(key)
+    let wipedDirectory = await repository.loadGalleryDirectory()
+    let wipedSession = await repository.loadSession()
+    XCTAssertNil(wipedFeed)
+    XCTAssertNil(wipedDirectory)
+    XCTAssertNil(wipedSession)
+  }
+
+  func testPruneStaleRemovesOnlyOldFeeds() async throws {
+    let staleKey = PhotoFeedKey.manifest("stale")
+    await repository.saveFeed(staleKey, photos: [NativeFixtureTestSupport.photo(id: "stale-1")], etag: nil)
+    try await Task.sleep(nanoseconds: 50_000_000)
+    let cutoff = Date()
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let freshKey = PhotoFeedKey.manifest("fresh")
+    await repository.saveFeed(freshKey, photos: [NativeFixtureTestSupport.photo(id: "fresh-1")], etag: nil)
+
+    await repository.pruneStale(olderThan: cutoff)
+
+    let staleLoaded = await repository.loadFeed(staleKey)
+    let freshLoaded = await repository.loadFeed(freshKey)
+    XCTAssertNil(staleLoaded)
+    XCTAssertNotNil(freshLoaded)
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Tests/PhotoFeedStoreCacheTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/PhotoFeedStoreCacheTests.swift
@@ -1,0 +1,264 @@
+import XCTest
+@testable import PhotoMasonry
+
+@MainActor
+final class PhotoFeedStoreCacheTests: XCTestCase {
+  func testColdStartWithCachePublishesCachedPhotosBeforeNetworkCompletes() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+    let cachedPhotos = [NativeFixtureTestSupport.photo(id: "cached-a")]
+    repository.seed(key, photos: cachedPhotos, etag: "etag-cached")
+
+    let transport = FakeManifestTransport(steps: [.notModified])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+
+    XCTAssertEqual(feed.photos.map(\.id), ["cached-a"])
+    XCTAssertEqual(feed.loadState, .loaded)
+
+    try await waitUntil { await transport.requestedEtags.count == 1 }
+  }
+
+  func testNotModifiedTouchesFeedAndKeepsCachedPhotosUnchanged() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+    let cachedPhotos = [NativeFixtureTestSupport.photo(id: "a"), NativeFixtureTestSupport.photo(id: "b")]
+    repository.seed(key, photos: cachedPhotos, etag: "etag-1")
+
+    let transport = FakeManifestTransport(steps: [.notModified])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+
+    try await waitUntil { repository.touchCalls.count == 1 }
+
+    let requestedEtags = await transport.requestedEtags
+    XCTAssertEqual(requestedEtags, ["etag-1"])
+    XCTAssertEqual(feed.photos, cachedPhotos)
+    XCTAssertEqual(feed.loadState, .loaded)
+    XCTAssertEqual(repository.touchCalls, [key])
+    XCTAssertTrue(repository.saveCalls.isEmpty)
+  }
+
+  func testSuccessPublishesDecodedPhotosAndPersistsNewOrderAndDeletions() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+    let cachedPhotos = [NativeFixtureTestSupport.photo(id: "a"), NativeFixtureTestSupport.photo(id: "b")]
+    repository.seed(key, photos: cachedPhotos, etag: "etag-1")
+
+    let payload = manifestData(ids: ["c", "b"])
+    let transport = FakeManifestTransport(steps: [.success(payload, etag: "etag-2")])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+
+    try await waitUntil { feed.photos.map(\.id) == ["c", "b"] }
+
+    XCTAssertEqual(feed.loadState, .loaded)
+    XCTAssertEqual(repository.saveCalls.count, 1)
+    XCTAssertEqual(repository.saveCalls.first?.key, key)
+    XCTAssertEqual(repository.saveCalls.first?.photos.map(\.id), ["c", "b"])
+    XCTAssertEqual(repository.saveCalls.first?.etag, "etag-2")
+  }
+
+  func testRefreshFailureKeepsCachedPhotosOnScreenAndLogsOnly() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+    let cachedPhotos = [NativeFixtureTestSupport.photo(id: "a")]
+    repository.seed(key, photos: cachedPhotos, etag: "etag-1")
+
+    let transport = FakeManifestTransport(steps: [.failure(APIError.http(status: 500, body: nil))])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+
+    XCTAssertEqual(feed.photos.map(\.id), ["a"])
+    XCTAssertEqual(feed.loadState, .loaded)
+
+    try await waitUntil { await transport.requestedEtags.count == 1 }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    XCTAssertEqual(feed.photos.map(\.id), ["a"])
+    XCTAssertEqual(feed.loadState, .loaded)
+    XCTAssertTrue(repository.saveCalls.isEmpty)
+    XCTAssertTrue(repository.touchCalls.isEmpty)
+  }
+
+  func testNoCachePathShowsLoadingThenLoaded() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+
+    let payload = manifestData(ids: ["x"])
+    let transport = FakeManifestTransport(steps: [.success(payload, etag: "etag-x")])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+
+    XCTAssertEqual(feed.loadState, .loading)
+    XCTAssertTrue(feed.photos.isEmpty)
+
+    try await waitUntil { feed.loadState == .loaded }
+
+    XCTAssertEqual(feed.photos.map(\.id), ["x"])
+    XCTAssertEqual(repository.saveCalls.first?.etag, "etag-x")
+  }
+
+  func testNoCachePathKeepsExistingErrorStateOnFailure() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+
+    let transport = FakeManifestTransport(steps: [.failure(APIError.http(status: 500, body: nil))])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+
+    XCTAssertEqual(feed.loadState, .loading)
+
+    try await waitUntil { feed.loadState == .failed }
+
+    XCTAssertNotNil(feed.lastError)
+    XCTAssertTrue(feed.photos.isEmpty)
+  }
+
+  func testStudioKeyNeverTouchesRepository() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    repository.seed(.studioLibrary, photos: [NativeFixtureTestSupport.photo(id: "seed")], etag: "seed-etag")
+
+    let transport = FakeManifestTransport(steps: [])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(.studioLibrary)
+    let feed = store.feed(for: .studioLibrary)
+
+    XCTAssertEqual(feed.loadState, .loading)
+    XCTAssertTrue(feed.photos.isEmpty)
+    XCTAssertTrue(repository.loadCalls.isEmpty)
+
+    try await waitUntil { feed.loadState != .loading }
+
+    XCTAssertTrue(repository.loadCalls.isEmpty)
+    XCTAssertTrue(repository.saveCalls.isEmpty)
+    XCTAssertTrue(repository.touchCalls.isEmpty)
+    let requestedEtagsCount = await transport.requestedEtags.count
+    XCTAssertEqual(requestedEtagsCount, 0)
+  }
+
+  private func manifestData(ids: [String]) -> Data {
+    let photos = ids.map { id in ["id": id, "thumbnailUrl": "https://example.com/\(id).jpg"] }
+    return try! JSONSerialization.data(withJSONObject: ["data": photos])
+  }
+
+  private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () async -> Bool
+  ) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while await !condition() {
+      if Date() >= deadline {
+        XCTFail("Timed out waiting for condition")
+        return
+      }
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+  }
+}
+
+private actor FakeManifestTransport: ManifestTransport {
+  enum Step {
+    case notModified
+    case success(Data, etag: String?)
+    case failure(Error)
+  }
+
+  private var steps: [Step]
+  private(set) var requestedEtags: [String?] = []
+
+  init(steps: [Step]) {
+    self.steps = steps
+  }
+
+  func fetchManifest(slug: String, etag: String?) async throws -> ManifestFetchOutcome {
+    requestedEtags.append(etag)
+    let step = steps.isEmpty ? Step.notModified : steps.removeFirst()
+    switch step {
+    case .notModified:
+      return .notModified
+    case .success(let data, let responseEtag):
+      return .success(data, etag: responseEtag)
+    case .failure(let error):
+      throw error
+    }
+  }
+}
+
+private final class RecordingPhotoCacheRepository: PhotoCacheRepository, @unchecked Sendable {
+  private struct Record {
+    var photos: [GalleryPhoto]
+    var etag: String?
+  }
+
+  private let lock = NSLock()
+  private var feeds: [PhotoFeedKey: Record] = [:]
+  private var _loadCalls: [PhotoFeedKey] = []
+  private var _saveCalls: [(key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?)] = []
+  private var _touchCalls: [PhotoFeedKey] = []
+
+  var loadCalls: [PhotoFeedKey] { lock.withLock { _loadCalls } }
+  var saveCalls: [(key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?)] { lock.withLock { _saveCalls } }
+  var touchCalls: [PhotoFeedKey] { lock.withLock { _touchCalls } }
+
+  func seed(_ key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?) {
+    lock.withLock { feeds[key] = Record(photos: photos, etag: etag) }
+  }
+
+  @MainActor
+  func loadFeed(_ key: PhotoFeedKey) -> (photos: [GalleryPhoto], etag: String?)? {
+    lock.withLock {
+      _loadCalls.append(key)
+      guard let record = feeds[key] else { return nil }
+      return (record.photos, record.etag)
+    }
+  }
+
+  func saveFeed(_ key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?) async {
+    lock.withLock {
+      _saveCalls.append((key, photos, etag))
+      feeds[key] = Record(photos: photos, etag: etag)
+    }
+  }
+
+  func touchFeed(_ key: PhotoFeedKey) async {
+    lock.withLock { _touchCalls.append(key) }
+  }
+
+  @MainActor
+  func loadGalleryDirectory() -> Data? { nil }
+
+  func saveGalleryDirectory(_ payload: Data) async {}
+
+  @MainActor
+  func loadSession() -> Data? { nil }
+
+  func saveSession(_ payload: Data) async {}
+
+  func clearSession() async {}
+
+  func wipeAll() async {}
+
+  func pruneStale(olderThan cutoff: Date) async {}
+}
+
+private extension NSLock {
+  func withLock<T>(_ body: () -> T) -> T {
+    lock()
+    defer { unlock() }
+    return body()
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Tests/PhotoFeedStoreCacheTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/PhotoFeedStoreCacheTests.swift
@@ -150,6 +150,42 @@ final class PhotoFeedStoreCacheTests: XCTestCase {
     XCTAssertEqual(requestedEtagsCount, 0)
   }
 
+  func testStaleCancelledTaskDoesNotClobberTheNewerLoadRegistration() async throws {
+    let repository = RecordingPhotoCacheRepository()
+    let key = PhotoFeedKey.manifest("acme")
+
+    let gates = OneShotGates()
+    repository.touchFeedGate = { index in await gates.wait(index) }
+
+    let transport = FakeManifestTransport(steps: [.notModified, .notModified])
+    let store = PhotoFeedStore(repository: repository, manifestTransport: transport)
+
+    store.load(key)
+    let feed = store.feed(for: key)
+    XCTAssertEqual(feed.loadState, .loading)
+
+    try await waitUntil { repository.touchCalls.count == 1 }
+
+    store.load(key, force: true)
+
+    try await waitUntil { repository.touchCalls.count == 2 }
+
+    await gates.open(1)
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    store.load(key)
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    XCTAssertEqual(
+      repository.touchCalls.count,
+      2,
+      "a stale cancelled task must not clear the in-flight registration for a newer task"
+    )
+
+    await gates.open(2)
+    await gates.open(3)
+  }
+
   private func manifestData(ids: [String]) -> Data {
     let photos = ids.map { id in ["id": id, "thumbnailUrl": "https://example.com/\(id).jpg"] }
     return try! JSONSerialization.data(withJSONObject: ["data": photos])
@@ -167,6 +203,21 @@ final class PhotoFeedStoreCacheTests: XCTestCase {
       }
       try await Task.sleep(nanoseconds: 10_000_000)
     }
+  }
+}
+
+private actor OneShotGates {
+  private var opened: Set<Int> = []
+  private var waiters: [Int: CheckedContinuation<Void, Never>] = [:]
+
+  func wait(_ index: Int) async {
+    if opened.contains(index) { return }
+    await withCheckedContinuation { waiters[index] = $0 }
+  }
+
+  func open(_ index: Int) {
+    opened.insert(index)
+    waiters.removeValue(forKey: index)?.resume()
   }
 }
 
@@ -210,6 +261,8 @@ private final class RecordingPhotoCacheRepository: PhotoCacheRepository, @unchec
   private var _saveCalls: [(key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?)] = []
   private var _touchCalls: [PhotoFeedKey] = []
 
+  var touchFeedGate: (@Sendable (Int) async -> Void)?
+
   var loadCalls: [PhotoFeedKey] { lock.withLock { _loadCalls } }
   var saveCalls: [(key: PhotoFeedKey, photos: [GalleryPhoto], etag: String?)] { lock.withLock { _saveCalls } }
   var touchCalls: [PhotoFeedKey] { lock.withLock { _touchCalls } }
@@ -235,7 +288,13 @@ private final class RecordingPhotoCacheRepository: PhotoCacheRepository, @unchec
   }
 
   func touchFeed(_ key: PhotoFeedKey) async {
-    lock.withLock { _touchCalls.append(key) }
+    let callIndex: Int = lock.withLock {
+      _touchCalls.append(key)
+      return _touchCalls.count
+    }
+    if let touchFeedGate {
+      await touchFeedGate(callIndex)
+    }
   }
 
   @MainActor

--- a/apps/mobile/modules/photo-masonry/ios/Tests/SessionStoreCacheTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/SessionStoreCacheTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+@testable import PhotoMasonry
+
+@MainActor
+final class SessionStoreCacheTests: XCTestCase {
+  private static let cookie = "afilmory-tenant.session=abc"
+
+  func testBootstrapPublishesTheCachedSessionBeforeTheNetworkResponds() async throws {
+    let session = Self.makeSession()
+    let repository = InMemoryPhotoCacheRepository()
+    try await Self.seed(session, in: repository)
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let gate = Gate()
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())], gate: gate)
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    let recorder = StateRecorder()
+    let token = store.observe { recorder.record($0) }
+
+    store.bootstrap()
+
+    XCTAssertEqual(store.current().state, .signedIn(session))
+    XCTAssertEqual(recorder.states.last, .signedIn(session))
+
+    try await waitUntil { await transport.requestCount == 1 }
+    XCTAssertEqual(store.current().state, .signedIn(session))
+
+    await gate.open()
+    token.cancel()
+  }
+
+  func testConcurrentBootstrapsIssueASingleSessionRequest() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let gate = Gate()
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())], gate: gate)
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    for _ in 0..<8 {
+      store.bootstrap()
+    }
+
+    try await waitUntil { await transport.requestCount == 1 }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 1)
+
+    await gate.open()
+  }
+
+  func testBootstrapJoinsAnAlreadyRunningRefresh() async throws {
+    let session = Self.makeSession()
+    let repository = InMemoryPhotoCacheRepository()
+    try await Self.seed(session, in: repository)
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let gate = Gate()
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())], gate: gate)
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.refreshSession()
+    try await waitUntil { await transport.requestCount == 1 }
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .signedIn(session))
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 1)
+
+    await gate.open()
+  }
+
+  func testRefreshFailureKeepsTheCachedSignedInState() async throws {
+    let session = Self.makeSession()
+    let repository = InMemoryPhotoCacheRepository()
+    try await Self.seed(session, in: repository)
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(steps: [.failure(APIError.transport(URLError(.notConnectedToInternet)))])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .signedIn(session))
+
+    try await waitUntil { await transport.requestCount == 1 }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    XCTAssertEqual(store.current().state, .signedIn(session))
+    XCTAssertNotNil(cookies.read())
+    XCTAssertNotNil(repository.loadSession())
+  }
+
+  func testServerErrorWithoutACachedSessionKeepsTheStoredCookie() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(steps: [.failure(APIError.http(status: 500, body: nil))])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .loading)
+
+    try await waitUntil { store.current().state != .loading }
+
+    XCTAssertNil(store.current().state.session)
+    XCTAssertNotEqual(store.current().state, .signedOut)
+    XCTAssertNotNil(cookies.read())
+  }
+
+  func testUnauthorizedRefreshClearsTheCookieAndWipesTheCache() async throws {
+    let session = Self.makeSession()
+    let repository = InMemoryPhotoCacheRepository()
+    try await Self.seed(session, in: repository)
+    await repository.saveGalleryDirectory(Data("{}".utf8))
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(steps: [.failure(APIError.unauthorized)])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .signedIn(session))
+
+    try await waitUntil { store.current().state == .signedOut }
+    try await waitUntil { await MainActor.run { repository.loadSession() == nil } }
+
+    XCTAssertNil(cookies.read())
+    XCTAssertNil(repository.loadGalleryDirectory())
+  }
+
+  func testSuccessfulRefreshPublishesAndPersistsTheSession() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .loading)
+
+    try await waitUntil { store.current().state == .signedIn(Self.makeSession()) }
+    try await waitUntil { await MainActor.run { repository.loadSession() != nil } }
+
+    let payload = try XCTUnwrap(repository.loadSession())
+    let persisted = try JSONDecoder().decode(AfilmorySession.self, from: payload)
+    XCTAssertEqual(persisted, Self.makeSession())
+  }
+
+  func testCorruptedCachedSessionIsIgnoredAtBootstrap() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    await repository.saveSession(Data("not-a-session".utf8))
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let gate = Gate()
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())], gate: gate)
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .loading)
+
+    try await waitUntil { await transport.requestCount == 1 }
+    await gate.open()
+    try await waitUntil { store.current().state == .signedIn(Self.makeSession()) }
+  }
+
+  func testBootstrapWithoutACookiePublishesSignedOutWithoutRequesting() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    try await Self.seed(Self.makeSession(), in: repository)
+    let cookies = InMemorySessionCookieStorage()
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .signedOut)
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 0)
+  }
+
+  func testClearSessionWipesTheCacheAndTheCookie() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    try await Self.seed(Self.makeSession(), in: repository)
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(steps: [])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.clearSession()
+
+    XCTAssertEqual(store.current().state, .signedOut)
+    XCTAssertNil(cookies.read())
+    try await waitUntil { await MainActor.run { repository.loadSession() == nil } }
+  }
+
+  func testRegisteringACookieRestartsTheInFlightRefresh() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let gate = Gate()
+    let transport = FakeSessionTransport(
+      steps: [.success(Self.makeResponse()), .success(Self.makeResponse())],
+      gate: gate
+    )
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    try await waitUntil { await transport.requestCount == 1 }
+
+    store.register(cookie: "afilmory-tenant.session=refreshed")
+    try await waitUntil { await transport.requestCount == 2 }
+
+    XCTAssertEqual(cookies.read(), "afilmory-tenant.session=refreshed")
+    await gate.open()
+  }
+
+  private static func seed(_ session: AfilmorySession, in repository: InMemoryPhotoCacheRepository) async throws {
+    let payload = try JSONEncoder().encode(session)
+    await repository.saveSession(payload)
+  }
+
+  private static func makeSession() -> AfilmorySession {
+    makeResponse().resolved()!
+  }
+
+  private static func makeResponse() -> AfilmorySessionResponse {
+    let workspace = AfilmorySessionWorkspace(
+      id: "workspace-1",
+      slug: "acme",
+      name: "Acme",
+      status: "active",
+      isPlaceholder: nil
+    )
+    return AfilmorySessionResponse(
+      user: AfilmorySessionUser(id: "user-1", name: "Ada", email: "ada@example.com", image: nil, role: "user"),
+      activeWorkspace: workspace,
+      requestedWorkspace: nil,
+      requestedMembership: nil,
+      memberships: [
+        AfilmorySessionMembership(id: "membership-1", role: "owner", status: "active", workspace: workspace),
+      ]
+    )
+  }
+
+  private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () async -> Bool
+  ) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while await !condition() {
+      if Date() >= deadline {
+        XCTFail("Timed out waiting for condition")
+        return
+      }
+      try await Task.sleep(nanoseconds: 10_000_000)
+    }
+  }
+}
+
+private actor Gate {
+  private var opened = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    if opened { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func open() {
+    opened = true
+    for waiter in waiters {
+      waiter.resume()
+    }
+    waiters.removeAll()
+  }
+}
+
+private actor FakeSessionTransport: SessionTransport {
+  enum Step {
+    case success(AfilmorySessionResponse)
+    case failure(Error)
+  }
+
+  private var steps: [Step]
+  private let gate: Gate?
+  private(set) var requestCount = 0
+
+  init(steps: [Step], gate: Gate? = nil) {
+    self.steps = steps
+    self.gate = gate
+  }
+
+  func fetchSession() async throws -> AfilmorySessionResponse? {
+    requestCount += 1
+    let step = steps.isEmpty ? Step.failure(APIError.cancelled) : steps.removeFirst()
+    if let gate {
+      await gate.wait()
+    }
+    switch step {
+    case .success(let response):
+      return response
+    case .failure(let error):
+      throw error
+    }
+  }
+}
+
+private final class InMemorySessionCookieStorage: SessionCookieStorage, @unchecked Sendable {
+  private let lock = NSLock()
+  private var cookie: String?
+
+  init(cookie: String? = nil) {
+    self.cookie = cookie
+  }
+
+  func read() -> String? {
+    lock.withLock { cookie }
+  }
+
+  func write(_ cookie: String) {
+    lock.withLock { self.cookie = cookie }
+  }
+
+  func clear() {
+    lock.withLock { cookie = nil }
+  }
+}
+
+private final class StateRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var recorded: [AfilmorySessionState] = []
+
+  var states: [AfilmorySessionState] {
+    lock.withLock { recorded }
+  }
+
+  func record(_ state: AfilmorySessionState) {
+    lock.withLock { recorded.append(state) }
+  }
+}
+
+private extension NSLock {
+  func withLock<T>(_ body: () -> T) -> T {
+    lock()
+    defer { unlock() }
+    return body()
+  }
+}

--- a/apps/mobile/modules/photo-masonry/ios/Tests/SessionStoreCacheTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/SessionStoreCacheTests.swift
@@ -71,6 +71,78 @@ final class SessionStoreCacheTests: XCTestCase {
     await gate.open()
   }
 
+  func testBootstrapRetriesAfterAFailedRefresh() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(
+      steps: [.failure(APIError.transport(URLError(.notConnectedToInternet))), .success(Self.makeResponse())]
+    )
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    try await waitUntil { store.current().state != .loading }
+    XCTAssertNil(store.current().state.session)
+
+    store.bootstrap()
+
+    try await waitUntil { store.current().state == .signedIn(Self.makeSession()) }
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 2)
+  }
+
+  func testBootstrapRetriesAfterAnUnreadableCookieAtLaunch() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage()
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    XCTAssertEqual(store.current().state, .signedOut)
+
+    cookies.write(Self.cookie)
+    store.bootstrap()
+
+    try await waitUntil { store.current().state == .signedIn(Self.makeSession()) }
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 1)
+  }
+
+  func testForegroundingRetriesAnUnresolvedSession() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(
+      steps: [.failure(APIError.transport(URLError(.notConnectedToInternet))), .success(Self.makeResponse())]
+    )
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    try await waitUntil { store.current().state != .loading }
+    XCTAssertNil(store.current().state.session)
+
+    NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+    try await waitUntil { store.current().state == .signedIn(Self.makeSession()) }
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 2)
+  }
+
+  func testBootstrapDoesNotRefetchOnceTheSessionIsResolved() async throws {
+    let repository = InMemoryPhotoCacheRepository()
+    let cookies = InMemorySessionCookieStorage(cookie: Self.cookie)
+    let transport = FakeSessionTransport(steps: [.success(Self.makeResponse())])
+    let store = AfilmorySessionStore(repository: repository, transport: transport, cookieStorage: cookies)
+
+    store.bootstrap()
+    try await waitUntil { store.current().state == .signedIn(Self.makeSession()) }
+
+    store.bootstrap()
+    store.bootstrap()
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let requestCount = await transport.requestCount
+    XCTAssertEqual(requestCount, 1)
+  }
+
   func testRefreshFailureKeepsTheCachedSignedInState() async throws {
     let session = Self.makeSession()
     let repository = InMemoryPhotoCacheRepository()

--- a/apps/mobile/src/api/auth.ts
+++ b/apps/mobile/src/api/auth.ts
@@ -6,6 +6,10 @@ export function getAuthCookie(): string | null {
   return authCookie
 }
 
+export function adoptAuthCookie(cookie: string | null): void {
+  authCookie = cookie
+}
+
 export function setAuthCookie(cookie: string | null): void {
   authCookie = cookie
   if (cookie) {

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -5,7 +5,7 @@ import { useCallback, useRef } from 'react'
 import { useTranslation } from '@/i18n'
 import { useAuth } from '@/modules/auth/sessionStore'
 import { createDevLabShortcutState, registerDevLabTabPress } from '@/modules/shell/devLabShortcut'
-import { getAvailableTabNames, shouldShowTabBar } from '@/modules/shell/tabAccess'
+import { getAvailableTabNames, isVisitorStatus, shouldShowTabBar } from '@/modules/shell/tabAccess'
 import { useTheme } from '@/theme/useTheme'
 
 export default function TabLayout() {
@@ -17,7 +17,7 @@ export default function TabLayout() {
   const isStudio = segments.includes('studio')
   const isExplore = segments.includes('explore')
   const availableTabs = getAvailableTabNames(auth.status)
-  const isSignedOut = auth.status === 'signedOut'
+  const isVisitor = isVisitorStatus(auth.status)
   const devLabShortcutStateRef = useRef(createDevLabShortcutState())
   const handleTabPress = useCallback(
     (tabName: string) => {
@@ -39,7 +39,7 @@ export default function TabLayout() {
     return null
   }
 
-  if (isSignedOut && !isExplore) {
+  if (isVisitor && !isExplore) {
     return <Redirect href="/explore" />
   }
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -23,9 +23,9 @@ export default function RootLayout() {
   // Nothing may issue a request before the API environment override resolves,
   // otherwise the first fetch races against the production default.
   useEffect(() => {
-    void Promise.all([waitForEnvironment(), waitForAuthStorage()]).then(async () => {
+    void Promise.all([waitForEnvironment(), waitForAuthStorage()]).then(() => {
       setEnvironmentReady(true)
-      await hydrateAuth()
+      hydrateAuth()
     })
   }, [])
 

--- a/apps/mobile/src/modules/auth/sessionStore.ts
+++ b/apps/mobile/src/modules/auth/sessionStore.ts
@@ -24,11 +24,12 @@ import type {
   SessionInfo,
 } from './types'
 
-export type AuthStatus = 'loading' | 'signedIn' | 'signedOut'
+export type AuthStatus = 'failed' | 'loading' | 'signedIn' | 'signedOut'
 
 export interface AuthState {
   status: AuthStatus
   session: SessionInfo | null
+  error?: string
 }
 
 let state: AuthState = { status: 'loading', session: null }
@@ -85,13 +86,15 @@ function mirrorNativeSession(snapshot: NativeSessionSnapshot): void {
   }
 
   if (snapshot.status === 'signedOut') {
-    const revoked = state.status === 'signedIn'
     adoptAuthCookie(null)
     setActiveWorkspace(null)
     setState({ status: 'signedOut', session: null })
-    if (revoked) {
-      void clearAuthStorage()
-    }
+    return
+  }
+
+  // A failed refresh never downgrades a session an interactive flow already established.
+  if (snapshot.status === 'failed' && state.status !== 'signedIn') {
+    setState({ status: 'failed', session: null, error: snapshot.error })
   }
 }
 

--- a/apps/mobile/src/modules/auth/sessionStore.ts
+++ b/apps/mobile/src/modules/auth/sessionStore.ts
@@ -1,7 +1,9 @@
 import { useSyncExternalStore } from 'react'
 
-import { setAuthCookie } from '@/api/auth'
+import { adoptAuthCookie, setAuthCookie } from '@/api/auth'
 import { setActiveTenantSlug } from '@/api/client'
+import type { NativeSessionSnapshot } from '@/native/afilmorySession'
+import { addNativeSessionListener, getNativeSessionSnapshot } from '@/native/afilmorySession'
 
 import {
   createWorkspace,
@@ -30,6 +32,7 @@ export interface AuthState {
 }
 
 let state: AuthState = { status: 'loading', session: null }
+let mirroringNativeSession = false
 const listeners = new Set<() => void>()
 
 function setState(next: AuthState) {
@@ -70,22 +73,36 @@ function setSignedIn(session: SessionInfo, cookie: string | null) {
   setState({ status: 'signedIn', session })
 }
 
-export async function hydrateAuth(): Promise<void> {
-  try {
-    const cookie = getAuthClient().getCookie()
-    if (!cookie) {
-      resetToSignedOut()
+function mirrorNativeSession(snapshot: NativeSessionSnapshot): void {
+  if (snapshot.status === 'signedIn') {
+    if (!snapshot.session) {
       return
     }
-    const session = await fetchSession(cookie)
-    if (!session) {
-      resetToSignedOut()
-      return
-    }
-    setSignedIn(session, cookie)
+    adoptAuthCookie(getAuthClient().getCookie())
+    setActiveWorkspace(snapshot.session.activeWorkspace?.slug)
+    setState({ status: 'signedIn', session: snapshot.session })
+    return
   }
-  catch {
-    resetToSignedOut()
+
+  if (snapshot.status === 'signedOut') {
+    const revoked = state.status === 'signedIn'
+    adoptAuthCookie(null)
+    setActiveWorkspace(null)
+    setState({ status: 'signedOut', session: null })
+    if (revoked) {
+      void clearAuthStorage()
+    }
+  }
+}
+
+export function hydrateAuth(): void {
+  if (!mirroringNativeSession) {
+    mirroringNativeSession = true
+    addNativeSessionListener(mirrorNativeSession)
+  }
+  const snapshot = getNativeSessionSnapshot()
+  if (snapshot) {
+    mirrorNativeSession(snapshot)
   }
 }
 
@@ -214,21 +231,6 @@ export async function switchWorkspace(tenantId: string): Promise<void> {
   setSignedIn(session, cookie)
 }
 
-export async function synchronizeWorkspaceFromNative(slug: string): Promise<void> {
+export function synchronizeWorkspaceFromNative(slug: string): void {
   setActiveWorkspace(slug)
-  const cookie = getAuthClient().getCookie()
-  if (!cookie) {
-    return
-  }
-
-  try {
-    const session = await fetchSession(cookie)
-    if (session) {
-      setSignedIn(session, cookie)
-    }
-  }
-  catch {
-    // The native session has already switched. Keep the tenant routing correct
-    // and allow the next auth hydration to refresh the JS session snapshot.
-  }
 }

--- a/apps/mobile/src/modules/shell/tabAccess.test.mjs
+++ b/apps/mobile/src/modules/shell/tabAccess.test.mjs
@@ -21,3 +21,9 @@ test('does not expose navigation while authentication is loading', () => {
   assert.equal(getDefaultTabPath('loading'), null)
   assert.equal(shouldShowTabBar('loading'), false)
 })
+
+test('falls back to the visitor surface when the session cannot be resolved', () => {
+  assert.deepEqual(getAvailableTabNames('failed'), ['explore'])
+  assert.equal(getDefaultTabPath('failed'), '/explore')
+  assert.equal(shouldShowTabBar('failed'), false)
+})

--- a/apps/mobile/src/modules/shell/tabAccess.ts
+++ b/apps/mobile/src/modules/shell/tabAccess.ts
@@ -3,14 +3,19 @@ import type { AuthStatus } from '@/modules/auth/sessionStore'
 export type AppTabName = 'photos' | 'map' | 'explore' | 'studio'
 
 const AUTHENTICATED_TABS: readonly AppTabName[] = ['photos', 'map', 'explore', 'studio']
-const SIGNED_OUT_TABS: readonly AppTabName[] = ['explore']
+const VISITOR_TABS: readonly AppTabName[] = ['explore']
+
+// An unresolvable session browses as a visitor; it must never strand the app on a blank screen.
+export function isVisitorStatus(status: AuthStatus): boolean {
+  return status === 'signedOut' || status === 'failed'
+}
 
 export function getAvailableTabNames(status: AuthStatus): readonly AppTabName[] {
   if (status === 'signedIn') {
     return AUTHENTICATED_TABS
   }
-  if (status === 'signedOut') {
-    return SIGNED_OUT_TABS
+  if (isVisitorStatus(status)) {
+    return VISITOR_TABS
   }
   return []
 }
@@ -19,7 +24,7 @@ export function getDefaultTabPath(status: AuthStatus): '/photos' | '/explore' | 
   if (status === 'signedIn') {
     return '/photos'
   }
-  if (status === 'signedOut') {
+  if (isVisitorStatus(status)) {
     return '/explore'
   }
   return null

--- a/apps/mobile/src/native/NativePageView.tsx
+++ b/apps/mobile/src/native/NativePageView.tsx
@@ -45,7 +45,7 @@ export function NativePageView({ galleryRoute, page }: { galleryRoute?: string, 
       return
     }
     if (event.nativeEvent.type === 'workspaceChanged') {
-      void synchronizeWorkspaceFromNative(event.nativeEvent.workspaceSlug)
+      synchronizeWorkspaceFromNative(event.nativeEvent.workspaceSlug)
       return
     }
     if (event.nativeEvent.type === 'workspaceSetup') {

--- a/apps/mobile/src/native/afilmorySession.ts
+++ b/apps/mobile/src/native/afilmorySession.ts
@@ -2,7 +2,17 @@ import { requireNativeModule } from 'expo'
 import Constants from 'expo-constants'
 import { Platform } from 'react-native'
 
+import type { SessionInfo } from '@/modules/auth/types'
+
 export type AfilmoryAppVariant = 'local' | 'production'
+
+export type NativeSessionStatus = 'failed' | 'loading' | 'signedIn' | 'signedOut'
+
+export interface NativeSessionSnapshot {
+  error?: string
+  session: SessionInfo | null
+  status: NativeSessionStatus
+}
 
 export interface AfilmoryBuildConfiguration {
   allowsApiEnvironmentOverride: boolean
@@ -13,8 +23,10 @@ export interface AfilmoryBuildConfiguration {
 }
 
 interface AfilmorySessionNativeModule {
+  addListener: (event: 'onSessionChange', listener: (snapshot: NativeSessionSnapshot) => void) => { remove: () => void }
   clearSession: () => void
   getBuildConfiguration: () => AfilmoryBuildConfiguration
+  getSessionSnapshot: () => NativeSessionSnapshot
   hasStoredCookie: () => boolean
   registerSession: (cookie: string) => void
   setApiEnvironment: (
@@ -46,6 +58,20 @@ export function getBuildConfiguration(): AfilmoryBuildConfiguration {
   catch {
     return fallbackBuildConfiguration
   }
+}
+
+export function getNativeSessionSnapshot(): NativeSessionSnapshot | null {
+  try {
+    return nativeSession?.getSessionSnapshot() ?? null
+  }
+  catch {
+    return null
+  }
+}
+
+export function addNativeSessionListener(listener: (snapshot: NativeSessionSnapshot) => void): () => void {
+  const subscription = nativeSession?.addListener('onSessionChange', listener)
+  return () => subscription?.remove()
 }
 
 export function registerNativeSession(cookie: string): void {

--- a/be/apps/core/src/modules/content/manifest/manifest.public.controller.spec.ts
+++ b/be/apps/core/src/modules/content/manifest/manifest.public.controller.spec.ts
@@ -1,0 +1,98 @@
+import type { Context } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ManifestPublicController } from './manifest.public.controller'
+import type { ManifestService } from './manifest.service'
+import { computeManifestETag } from './manifest.service'
+
+function createContext(headers: Record<string, string> = {}): Context {
+  const normalized = new Map(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]))
+  return {
+    req: {
+      header: (name: string) => normalized.get(name.toLowerCase()),
+    },
+  } as unknown as Context
+}
+
+function createController(etag: string, manifest: unknown) {
+  const manifestService = {
+    getManifestETag: vi.fn(async () => etag),
+    getManifest: vi.fn(async () => manifest),
+  } as unknown as ManifestService
+
+  return { controller: new ManifestPublicController(manifestService), manifestService }
+}
+
+describe('computeManifestETag', () => {
+  it('produces the same etag for identical fingerprint inputs', () => {
+    const etagA = computeManifestETag('2026-08-06T00:00:00.000Z', 12)
+    const etagB = computeManifestETag('2026-08-06T00:00:00.000Z', 12)
+
+    expect(etagA).toBe(etagB)
+  })
+
+  it('produces a different etag when the max updatedAt changes', () => {
+    const original = computeManifestETag('2026-08-06T00:00:00.000Z', 12)
+    const afterUpdate = computeManifestETag('2026-08-06T00:05:00.000Z', 12)
+
+    expect(afterUpdate).not.toBe(original)
+  })
+
+  it('produces a different etag when the photo count changes', () => {
+    const original = computeManifestETag('2026-08-06T00:00:00.000Z', 12)
+    const afterInsert = computeManifestETag('2026-08-06T00:00:00.000Z', 13)
+
+    expect(afterInsert).not.toBe(original)
+  })
+
+  it('returns a strong etag with no weak-validator prefix', () => {
+    const etag = computeManifestETag(null, 0)
+
+    expect(etag.startsWith('W/')).toBe(false)
+    expect(etag).toMatch(/^"[0-9a-f]{64}"$/)
+  })
+})
+
+describe('manifestPublicController#getManifest', () => {
+  it('returns 304 with an empty body when If-None-Match matches the current etag', async () => {
+    const etag = '"current-etag"'
+    const { controller, manifestService } = createController(etag, {
+      version: '1',
+      data: [],
+      cameras: [],
+      lenses: [],
+    })
+
+    const response = await controller.getManifest(createContext({ 'if-none-match': etag }))
+
+    expect(response.status).toBe(304)
+    expect(response.headers.get('etag')).toBe(etag)
+    expect(await response.text()).toBe('')
+    expect(manifestService.getManifest).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with the manifest body and etag when If-None-Match is stale', async () => {
+    const currentEtag = '"current-etag"'
+    const manifest = { version: '1', data: [{ id: 'a' }], cameras: [], lenses: [] }
+    const { controller, manifestService } = createController(currentEtag, manifest)
+
+    const response = await controller.getManifest(createContext({ 'if-none-match': '"stale-etag"' }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('etag')).toBe(currentEtag)
+    expect(await response.json()).toEqual(manifest)
+    expect(manifestService.getManifest).toHaveBeenCalledOnce()
+  })
+
+  it('returns 200 with the manifest body when no If-None-Match header is present', async () => {
+    const currentEtag = '"current-etag"'
+    const manifest = { version: '1', data: [], cameras: [], lenses: [] }
+    const { controller, manifestService } = createController(currentEtag, manifest)
+
+    const response = await controller.getManifest(createContext())
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('etag')).toBe(currentEtag)
+    expect(manifestService.getManifest).toHaveBeenCalledOnce()
+  })
+})

--- a/be/apps/core/src/modules/content/manifest/manifest.public.controller.ts
+++ b/be/apps/core/src/modules/content/manifest/manifest.public.controller.ts
@@ -1,6 +1,7 @@
 import { BizException, ErrorCode } from '@core/errors'
 import { BypassResponseTransform } from '@core/interceptors/response-transform.decorator'
-import { Body, Controller, createZodSchemaDto, Get, Param, Post, Query } from '@tsuki-hono/common'
+import { Body, ContextParam, Controller, createZodSchemaDto, Get, Param, Post, Query } from '@tsuki-hono/common'
+import type { Context } from 'hono'
 import { z } from 'zod'
 
 import { ManifestService } from './manifest.service'
@@ -45,8 +46,39 @@ export class ManifestPublicController {
 
   @Get()
   @BypassResponseTransform()
-  async getManifest() {
-    return await this.manifestService.getManifest()
+  async getManifest(@ContextParam() context: Context): Promise<Response> {
+    const etag = await this.manifestService.getManifestETag()
+
+    const ifNoneMatch = context.req.header('if-none-match')
+    if (ifNoneMatch && this.matchesEtag(ifNoneMatch, etag)) {
+      return new Response(null, {
+        status: 304,
+        headers: { etag },
+      })
+    }
+
+    const manifest = await this.manifestService.getManifest()
+    return new Response(JSON.stringify(manifest), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        etag,
+      },
+    })
+  }
+
+  private matchesEtag(headerValue: string, currentEtag: string): boolean {
+    const trimmed = headerValue.trim()
+    if (trimmed === '*') {
+      return true
+    }
+
+    const candidates = trimmed
+      .split(',')
+      .map(entry => entry.trim())
+      .filter(entry => entry.length > 0)
+
+    return candidates.includes(currentEtag)
   }
 
   @Get('photos')

--- a/be/apps/core/src/modules/content/manifest/manifest.service.ts
+++ b/be/apps/core/src/modules/content/manifest/manifest.service.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 import type { AfilmoryManifest, CameraInfo, LensInfo, PhotoManifestItem } from '@afilmory/builder'
 import { CURRENT_MANIFEST_VERSION, migrateManifest } from '@afilmory/builder'
 import type { ManifestVersion } from '@afilmory/builder/manifest/version.js'
@@ -6,10 +8,17 @@ import { CURRENT_PHOTO_MANIFEST_VERSION, photoAssets } from '@afilmory/db'
 import { DbAccessor } from '@core/database/database.provider'
 import { requireTenantContext } from '@core/modules/platform/tenant/tenant.context'
 import { createLogger } from '@tsuki-hono/common'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, count, eq, inArray, max } from 'drizzle-orm'
 import { injectable } from 'tsyringe'
 
 import { ensureCurrentPhotoAssetManifest } from './manifest-migration.helper'
+
+export function computeManifestETag(maxUpdatedAt: string | null, photoCount: number): string {
+  const hash = createHash('sha256')
+    .update(`${maxUpdatedAt ?? ''}:${photoCount}`)
+    .digest('hex')
+  return `"${hash}"`
+}
 
 export interface AfilmorySearchQuery {
   tags?: string[]
@@ -34,6 +43,21 @@ export class ManifestService {
   private readonly logger = createLogger('ManifestService')
 
   constructor(private readonly dbAccessor: DbAccessor) {}
+
+  async getManifestETag(): Promise<string> {
+    const tenant = requireTenantContext()
+    const db = this.dbAccessor.get()
+
+    const [row] = await db
+      .select({
+        maxUpdatedAt: max(photoAssets.updatedAt),
+        photoCount: count(),
+      })
+      .from(photoAssets)
+      .where(and(eq(photoAssets.tenantId, tenant.tenant.id), inArray(photoAssets.syncStatus, ['synced', 'conflict'])))
+
+    return computeManifestETag(row?.maxUpdatedAt ?? null, row?.photoCount ?? 0)
+  }
 
   async getManifest(): Promise<AfilmoryManifest> {
     const tenant = requireTenantContext()

--- a/docs/superpowers/plans/2026-08-06-mobile-offline-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-06-mobile-offline-cache-plan.md
@@ -1,0 +1,143 @@
+# Mobile Offline Cache — Implementation Plan
+
+Spec: `docs/superpowers/specs/2026-08-06-mobile-offline-cache-design.md` (read it if a task's intent is unclear; task text below is authoritative for requirements).
+
+## Global Constraints
+
+- **Zero comments / zero JSDoc** in all code (Swift and TS). A comment is allowed only for a workaround/quirk or a hidden invariant a reader would otherwise reverse.
+- **`@Model` classes never leave the Persistence layer.** Stores publish the existing value types (`GalleryPhoto`, session structs). UI files (Masonry/, Viewer/, Filters/) must not change.
+- **Adapt to existing names.** Where this plan sketches a signature, the existing codebase's type/method names win; behavior contracts are binding, spelling is not.
+- **New `.swift` files are invisible until `pod install`** (podspec glob is expanded at install time). After adding/removing Swift files run `pod install` in `apps/mobile/ios` (or re-run prebuild) before building/testing.
+- **Native tests**: from `apps/mobile` — first time: `pnpm native:locales && npx expo prebuild -p ios`, then `pnpm native:test`. Test sources live in `apps/mobile/modules/photo-masonry/ios/Tests/`.
+- **Backend tests**: vitest in `be/apps/core` — `pnpm --filter core exec vitest run <file>`. Follow existing `*.spec.ts` patterns in that app.
+- **Lint/type-check only what you touched**: `pnpm lint <paths>`, `pnpm --filter @afilmory/mobile type-check` for mobile TS.
+- **ETag contract**: fingerprint of tenant manifest content = hash over (max photo `updatedAt`, photo count); `If-None-Match` match → `304` with empty body.
+- **Conditional native requests** must set `cachePolicy: .reloadIgnoringLocalCacheData` so Foundation's `URLCache` cannot answer revalidations itself.
+- **Lifecycle rules**: wipe all cached data on sign-out or 401; never wipe on workspace switch; prune feeds with `fetchedAt` older than 30 days at startup; SDWebImage `maxDiskSize` 512 MB, `maxDiskAge` 60 days.
+- **Error rules**: cached-JSON decode failure → drop rows, fall through to network, never crash; SwiftData container open/migration failure → delete store file, rebuild empty; background refresh failure with cache on screen → keep cache silently.
+- Commit per task with a conventional message (`feat(mobile): …`, `feat(be): …`, `test: …`). Never add AI co-authorship lines.
+
+## Task 1: Backend manifest ETag
+
+**Files:** `be/apps/core/src/modules/content/manifest/manifest.public.controller.ts`, its service, and a new/extended `*.spec.ts` beside existing manifest tests.
+
+`GET /api/manifest` must:
+
+1. Compute a stable content fingerprint for the tenant's manifest: hash (sha1/md5 — pick what the codebase already uses, e.g. node `crypto`) over `(max updatedAt across the tenant's synced photos, photo count)`. If the manifest service already maintains an equivalent monotonic version value, use it instead — same contract, cheaper. Look before building: check `manifest.service.ts` and the drizzle schema for an existing version/updatedAt aggregate.
+2. Send it as a strong `ETag` response header on 200 responses.
+3. When the request carries `If-None-Match` equal to the current ETag, return `304` with an empty body and the same `ETag` header, skipping manifest body serialization (it is fine to still run the cheap fingerprint query; it is NOT fine to build the full manifest payload on the 304 path).
+4. Behavior of every other manifest endpoint is unchanged.
+
+Framework note: this is the tsuki-hono (NestJS-style) framework — controllers use decorators; get access to raw request headers/response the way neighboring controllers do (check existing usages of headers/context in `be/apps/core` before inventing a pattern).
+
+**Tests (vitest):**
+- identical content → identical ETag across two calls
+- fingerprint input change → different ETag
+- `If-None-Match` with current ETag → 304, empty body
+- `If-None-Match` stale value → 200 with body + new ETag
+Follow the existing manifest/controller test setup in `be/apps/core` (mock service or test harness — mirror neighboring specs).
+
+**Verify:** scoped vitest run passes; `pnpm lint <changed files>`.
+
+## Task 2: Native persistence foundation (SwiftData)
+
+**Files (new):** `apps/mobile/modules/photo-masonry/ios/Persistence/AfilmoryDatabase.swift`, `Persistence/CacheModels.swift`, `Persistence/PhotoCacheRepository.swift`, `Persistence/SwiftDataPhotoCacheRepository.swift`, `Persistence/InMemoryPhotoCacheRepository.swift`, tests in `ios/Tests/PhotoCacheRepositoryTests.swift`.
+
+Build the persistence layer exactly as the spec's Architecture section defines:
+
+1. **`AfilmoryDatabase`**: owns the single `ModelContainer`; store file under Application Support (subdirectory `AfilmoryCache`). If container creation throws (migration/corruption), delete the store file and recreate empty — the cache is reproducible; never crash. Provide a test initializer using an in-memory `ModelConfiguration`.
+2. **`@Model` classes** (see spec Data model table): `CachedPhoto` (`photoId`, `feedKey`, `orderIndex`, `takenAt`, `payload: Data`; `#Unique` on `(feedKey, photoId)`; `#Index` on `feedKey`), `CachedFeed` (`feedKey` unique, `etag: String?`, `fetchedAt: Date`, `photoCount: Int`), `CachedGalleryDirectory` (singleton row: `payload: Data`, `fetchedAt`), `CachedSession` (singleton row: `payload: Data`, `fetchedAt`).
+3. **`PhotoCacheRepository` protocol** — the only surface stores will use. Required operations (adapt spelling to existing types like `PhotoFeedKey`, `GalleryPhoto`, and the native session struct):
+   - `loadFeed(key) -> (photos: [GalleryPhoto], etag: String?)?` — photos ordered by `orderIndex`; decode failures of individual payloads drop those rows (and delete them) rather than failing the load
+   - `saveFeed(key, photos, etag)` — full replace for that key: upsert by `(feedKey, photoId)`, delete rows absent from `photos`, rewrite `orderIndex` from array order, update `CachedFeed` row (`etag`, `fetchedAt = now`, `photoCount`)
+   - `touchFeed(key)` — update `fetchedAt` only
+   - `loadGalleryDirectory() -> Data?` / `saveGalleryDirectory(Data)`
+   - `loadSession() -> Data?` / `saveSession(Data)` / `clearSession()`
+   - `wipeAll()`
+   - `pruneStale(olderThan: Date)` — delete `CachedFeed` rows older than the cutoff and their `CachedPhoto` rows
+4. **Threading contract**: the load/hydration methods must be callable synchronously from `@MainActor` (main-context reads); mutations go through a `ModelActor` so they never block the main thread. Hide the split inside `SwiftDataPhotoCacheRepository`; the protocol may expose async mutations + sync reads.
+5. **`InMemoryPhotoCacheRepository`**: dictionary-backed fake implementing the same protocol, for tests of the stores in later tasks.
+
+No store wiring yet — this task is the layer plus its own tests.
+
+**Tests:** round-trip save/load of a feed (order preserved, etag persisted); upsert replaces changed payloads and deletes missing photos; corrupted payload row is dropped and deleted on load; `pruneStale` removes only stale feeds + their photos; `wipeAll` empties everything; session/directory round-trips.
+
+**Verify:** from `apps/mobile`: `pnpm native:locales && npx expo prebuild -p ios` (first prebuild in this worktree), then `pnpm native:test`. Existing tests must stay green.
+
+## Task 3: Feed stale-while-revalidate + conditional GET
+
+**Files:** `apps/mobile/modules/photo-masonry/ios/Core/AfilmoryAPI.swift`, `ios/Data/PhotoFeedStore.swift`, tests `ios/Tests/PhotoFeedStoreCacheTests.swift`.
+
+1. **`AfilmoryAPI`**: the manifest request gains conditional support — accept an optional etag; set `If-None-Match` when present; `cachePolicy = .reloadIgnoringLocalCacheData`; surface the outcome as a three-case result: `.notModified`, `.success(payload, etag: String?)` (etag read from the response header), or error. Keep the existing call shape for other endpoints. If `AfilmoryAPI` is not yet injectable into `PhotoFeedStore`, introduce the minimal seam (protocol or closure) needed for tests — mirror how `CommentsTransport` did it if such a seam exists.
+2. **`PhotoFeedStore.load(key)`** becomes stale-while-revalidate:
+   - hydrate: `repository.loadFeed(key)` → if non-nil, publish `.loaded(photos)` immediately; `.loading` only when there is no cache
+   - refresh (always, after hydrate): conditional manifest fetch with the stored etag
+     - `.notModified` → `repository.touchFeed(key)`; no publish
+     - `.success` → decode via existing `ManifestDecoding`, publish new array, `repository.saveFeed(key, photos, etag)`
+     - failure with cache on screen → keep published photos, log only; failure with no cache → existing error state (unchanged behavior)
+   - `force` reload keeps working and skips nothing except it must still send `If-None-Match` (a 304 on force is still valid)
+   - repository is injected (default: the SwiftData one; tests use `InMemoryPhotoCacheRepository`)
+3. The `studio` feed key is out of scope: it must bypass the cache entirely (no hydrate, no save) — guard by key kind, not by string comparison hacks.
+
+**Tests** (repository fake + mocked API): cold start with cache publishes cached photos before any network completion; 304 path touches feed and keeps array identity; 200 path publishes and persists new order/deletions; refresh failure keeps cached photos; no-cache path shows loading then loaded; studio key never touches the repository.
+
+**Verify:** `pod install` in `apps/mobile/ios`, then `pnpm native:test`.
+
+## Task 4: Native session authority + JS mirror
+
+**Files:** `apps/mobile/modules/photo-masonry/ios/Core/AfilmorySessionStore.swift`, `ios/Pages/NativePagesModule.swift`, `apps/mobile/src/modules/auth/sessionStore.ts`, `apps/mobile/src/native/` (session bridge surface), tests `ios/Tests/SessionStoreCacheTests.swift`.
+
+**Native:**
+
+1. `bootstrap()`: synchronously publish last known state — Keychain cookie + `repository.loadSession()` (decode the persisted session struct; treat decode failure as no cache). If both cookie and cached session exist → signed-in state with workspace slug available immediately.
+2. All concurrent `bootstrap()`/refresh calls coalesce into one in-flight `GET /api/auth/session` task; page controllers calling `bootstrap()` repeatedly must not stack requests.
+3. Refresh outcome: success → publish + `repository.saveSession(encoded)`; network/server failure (timeouts, 5xx, no connectivity) → keep current state; **HTTP 401 specifically** → transition to signed-out, clear Keychain cookie, `repository.wipeAll()`.
+4. Explicit sign-out (user action via JS) keeps its current path and additionally triggers `repository.wipeAll()`.
+
+**Bridge (`NativePagesModule`):** expose `getSessionSnapshot()` (sync or promise returning the serialized session state JS already understands) and a `sessionChange` event fired on every native session state transition.
+
+**JS:**
+
+5. `sessionStore.ts`: `hydrateAuth()` no longer fetches `/api/auth/session`. It reads the native snapshot and subscribes to `sessionChange`; the store remains a `useSyncExternalStore` source with the same public selectors so route guards (`tabAccess.ts`, `src/app/index.tsx`, `(tabs)/_layout.tsx`) keep working unchanged. A network failure can no longer produce `resetToSignedOut()` — only a native-reported signed-out state can.
+6. Auth flows (Apple sign-in, sign-out, account deletion, workspace switch) stay as they are; their completion already hands the cookie to native (`registerNativeSession`) — verify the handoff still triggers a native refresh + broadcast, and that JS-side sign-out reaches the native store (so wipe + broadcast happen).
+
+**Tests:** Swift — bootstrap with cached session publishes signed-in before network; coalescing (N concurrent bootstraps → 1 request); failure keeps state; 401 wipes repository and Keychain (use `InMemoryPhotoCacheRepository` + mocked API/Keychain seam as the store's design allows). JS behavior is covered by type-check + the route guards' unchanged contract; no new JS test harness.
+
+**Verify:** `pod install` + `pnpm native:test`; `pnpm --filter @afilmory/mobile type-check`; `pnpm lint <changed TS files>`.
+
+## Task 5: Gallery directory cache
+
+**Files:** `apps/mobile/modules/photo-masonry/ios/Pages/GalleriesController.swift` (and whatever native store/service it uses to fetch `GET /api/gallery-directory`), tests appended to an appropriate existing/new test file.
+
+1. On load: `repository.loadGalleryDirectory()` → if present, decode and render immediately (loading state only when empty), then refetch the directory unconditionally; on success re-render and `repository.saveGalleryDirectory(data)`; on failure keep rendered cache silently.
+2. Decode failure of cached data → ignore cache, fall through to network.
+3. If the directory fetch currently lives inline in the controller, extract the minimal loader seam so the cache path is testable — do not rebuild the controller.
+
+**Tests:** cached directory renders before network; refresh overwrites; corrupt cache falls through.
+
+**Verify:** `pod install` (if files added) + `pnpm native:test`.
+
+## Task 6: Lifecycle wiring — prune + SDWebImage limits
+
+**Files:** app/module startup path (where the masonry module or app delegate first initializes — follow where SDWebImage or `PhotoFeedStore` is first touched), `Persistence/` if a helper is needed; small test for the prune cutoff.
+
+1. Once per app launch (background priority, off the main thread, after first paint concerns — not blocking startup): `repository.pruneStale(olderThan: now - 30 days)`.
+2. Configure `SDImageCache.shared.config.maxDiskSize = 512 * 1024 * 1024` and `maxDiskAge = 60 * 24 * 3600` at the same initialization point.
+3. Double-check Task 4 left no sign-out path that skips `wipeAll()`.
+
+**Tests:** prune cutoff boundary (29-day-old feed survives, 31-day-old feed and its photos deleted) — likely already covered by Task 2's repository tests; add only what's missing at the wiring level (e.g. the launch hook calls prune exactly once).
+
+**Verify:** `pnpm native:test`.
+
+## Task 7: Whole-feature verification
+
+No production code except fixes for what this task uncovers.
+
+1. Full native suite: `pnpm native:test` from `apps/mobile` (after `pod install`).
+2. `pnpm --filter @afilmory/mobile type-check`.
+3. `pnpm lint` scoped to every TS file the branch touched.
+4. Backend: scoped vitest for the manifest module.
+5. `pnpm --filter @afilmory/mobile bundle` (export sanity check).
+6. Best-effort simulator smoke (do not block on it): build/launch the app on an iPhone simulator, screenshot the explore tab signed-out. Use `xcrun simctl` + `axe`; never control the mouse. If the environment makes this impractical, say so explicitly in the report instead of faking it.
+
+Report every command with its outcome. Any failure → fix within this task if mechanical, otherwise report BLOCKED with specifics.

--- a/docs/superpowers/specs/2026-08-06-mobile-offline-cache-design.md
+++ b/docs/superpowers/specs/2026-08-06-mobile-offline-cache-design.md
@@ -1,0 +1,119 @@
+# Mobile Offline Cache (SwiftData) — Design
+
+**Date:** 2026-08-06
+**Scope:** Give the iOS app an offline-first read path: cold start renders the photo grid, explore page, and subscribed galleries from a local SwiftData cache with zero network round-trips, then revalidates in the background. Kill the "offline user gets kicked to signed-out" defect. The read APIs participating in the cache (session, manifest, gallery directory) converge fully on the native side; JavaScript keeps only interactive auth flows.
+**Touches:** `apps/mobile/modules/photo-masonry/ios/Persistence/**` (new), `ios/Data/PhotoFeedStore.swift`, `ios/Core/AfilmorySessionStore.swift`, `ios/Core/AfilmoryAPI.swift`, `ios/Pages/GalleriesController.swift`, `ios/Pages/NativePagesModule.swift`, `apps/mobile/src/modules/auth/sessionStore.ts`, `apps/mobile/src/api/auth.ts`, `be/apps/core/src/modules/content/manifest/manifest.public.controller.ts` (+ service). New `.swift` files ⇒ `pod install` required.
+
+## Problem
+
+The app is a native app that behaves like a web page. Cold start renders nothing until **two sequential network round-trips** succeed: `GET /api/auth/session` (JS `hydrateAuth()` blocks the router; native `AfilmorySessionStore.bootstrap()` duplicates the same call from every page controller) and then `GET /api/manifest` (needs the workspace slug from the first). Offline, it is worse than blank: `hydrateAuth()`'s catch treats any failure — including plain network loss — as `resetToSignedOut()`, so a signed-in user with a valid Keychain cookie is redirected to `/explore` as if logged out.
+
+Nothing is persisted except the session cookie (Keychain) and the upload queue (`UploadCenter` JSON file). `PhotoFeedStore` is a process-lifetime in-memory singleton; every launch refetches the full manifest. Images are the only thing that survives a restart (SDWebImage disk cache, untuned defaults).
+
+Photo data never crosses the RN bridge — every primary screen is a native UIKit controller fed by Swift stores. The cache therefore lives on the native side; no JS persistence library helps the first screen.
+
+## Goals
+
+1. Cold start paints the photo grid from local data before any network I/O; a background refresh reconciles afterwards.
+2. Offline, the whole visitor browse path works from cache: photos grid, photo detail/viewer (images via SDWebImage disk cache), explore (gallery directory), subscribed gallery feeds.
+3. Network failure never signs the user out. Only an explicit 401 does.
+4. Steady-state launch refresh costs ~zero bytes: manifest revalidation via `ETag` / `If-None-Match` → 304.
+5. One session authority (native); the duplicated JS/native session fetches collapse into one.
+
+## Non-goals
+
+- Comments, reactions, studio (dashboard, data-sync, `GET /api/photos/assets` feed) stay online-only. Offline shows the existing unavailable/placeholder states.
+- No offline mutation queue (comments, subscriptions). Upload already has its own persistent queue.
+- Photo search (`POST /api/manifest/photos/search`) stays online-only.
+- No `updatedSince` / delta manifest API. Full payload + 304 is enough pre-release.
+- Interactive auth flows (Apple sign-in handshake, account deletion, workspace switch) stay in JS with better-auth / expo-apple-authentication. Native owns the session they produce, not the flows.
+- No proactive image prefetch for offline; the SDWebImage cache fills organically.
+- Remaining JS data calls outside the cache scope — studio's `useRemoteResource` endpoints and the galleries search fallback in `src/modules/galleries/api.ts` — are untouched this round; they are online-only features and migrating them buys no offline capability.
+
+## Decisions (confirmed)
+
+1. **SwiftData over Core Data** — iOS 26 deployment target, `@Model` + `ModelActor`, far less boilerplate.
+2. **Cache is native-side**, inside the photo-masonry module, because that is where the data lives.
+3. **Repository pattern, not `@Query`-driven UI** — SwiftData sits *behind* the existing stores. `@Model` classes never leave the Persistence layer; stores keep publishing the existing value-type structs (`GalleryPhoto`, `SessionInfo`), so masonry/viewer/filter code is untouched.
+4. **Backend gets `ETag` support on `GET /api/manifest`** — the one backend change this spec allows.
+5. **Cache scope**: session, manifest photo feeds (own workspace + subscribed gallery tenants), gallery directory.
+
+## Architecture
+
+New directory `apps/mobile/modules/photo-masonry/ios/Persistence/`:
+
+- **`AfilmoryDatabase`** — sole owner of the `ModelContainer`; store file in Application Support. Writes go through a `ModelActor`; the cold-start hydration read runs on the main actor so the first publish is synchronous with `bootstrap()`/`load()`.
+- **`PhotoCacheRepository`** (protocol + SwiftData implementation) — the only surface stores talk to:
+  - `loadFeed(_ key: PhotoFeedKey) -> (photos: [GalleryPhoto], etag: String?)?`
+  - `saveFeed(_ key:, photos:, etag:)` / `touchFeed(_ key:)`
+  - `loadGalleryDirectory() -> CachedDirectoryPayload?` / `saveGalleryDirectory(_:)`
+  - `loadSession() -> SessionInfo?` / `saveSession(_:)`
+  - `wipeAll()` / `pruneStale(olderThan:)`
+  - An in-memory fake implements the same protocol for tests.
+
+### Data model
+
+| `@Model` | Fields | Notes |
+|---|---|---|
+| `CachedPhoto` | `photoId`, `feedKey`, `orderIndex`, `takenAt`, `payload: Data` | `payload` is the full `GalleryPhoto` encoded as JSON. Identity is compound `(feedKey, photoId)`; a photo appearing in several feeds is stored once per feed — duplication traded for zero join tables. Indexed fields exist only for ordering/pruning queries. |
+| `CachedFeed` | `feedKey`, `etag`, `fetchedAt`, `photoCount` | Per-feed metadata; the ETag lives here. |
+| `CachedGalleryDirectory` | singleton row: `payload: Data`, `fetchedAt` | Explore page directory, whole response as JSON. |
+| `CachedSession` | singleton row: `payload: Data`, `fetchedAt` | Last successful `SessionInfo`. |
+
+JSON-blob columns are deliberate: `GalleryPhoto` is deeply nested (EXIF etc.) and already `Codable`; per-field columns would force a schema migration every time the manifest shape evolves, for queries we never run.
+
+## Data flow
+
+### Session (native is the single authority)
+
+`AfilmorySessionStore.bootstrap()`:
+
+1. Read Keychain cookie + `CachedSession` → publish signed-in state (workspace slug included) immediately.
+2. Kick one background `GET /api/auth/session`; concurrent `bootstrap()` calls from page controllers coalesce into a single in-flight task.
+3. On success → update store + `CachedSession`. On network failure → keep cached state, retry on next foreground/launch. On **401** → sign out, wipe cache.
+
+JS `hydrateAuth()` stops fetching. `NativePagesModule` exposes `getSessionSnapshot()` plus a session-change event; `sessionStore.ts` becomes a mirror via `useSyncExternalStore`. JS-initiated flows (Apple sign-in, sign-out, account deletion, workspace switch) complete as today, then hand the resulting cookie to native (`registerNativeSession`), which validates and broadcasts back.
+
+### Photo feeds (stale-while-revalidate)
+
+`PhotoFeedStore.load(key)`:
+
+1. `repository.loadFeed(key)` → if present, publish `.loaded(photos)` immediately. `.loading` (and its `UIContentUnavailableConfiguration` spinner) only appears when there is no cache.
+2. Background refresh: `GET /api/manifest` with `If-None-Match: <etag>`.
+   - **304** → `touchFeed`; done.
+   - **200** → decode, diff against the published array by `photoId` (upsert new/changed, delete missing, rewrite `orderIndex` from response order), publish, write back with the new ETag.
+   - Failure → keep published cache silently (log only).
+3. The request uses `cachePolicy: .reloadIgnoringLocalCacheData` — `URLCache` would otherwise transparently answer our conditional request from its own cache and we would double-store payloads. We own revalidation; Foundation must not.
+
+Subscribed galleries need nothing new: they already load through `PhotoFeedStore` with `manifest:<slug>` keys per tenant, so they inherit caching automatically.
+
+### Gallery directory
+
+`GalleriesController` follows the same pattern against `CachedGalleryDirectory`: publish cached payload, refetch full (no ETag — the payload is small), overwrite on success.
+
+## Backend change
+
+`manifest.public.controller.ts`, `GET /api/manifest` only:
+
+- Response carries `ETag` derived from a stable content fingerprint: hash of (max photo `updatedAt`, row count) for the tenant. If implementation reveals the manifest service already maintains an equivalent version value, that may substitute — same contract, cheaper query.
+- `If-None-Match` match → `304` with empty body.
+
+## Cache lifecycle
+
+- **Sign-out / 401** → `wipeAll()`. SDWebImage cache stays (thumbnails are not tenant-sensitive in a way worth the cold-image penalty; manual clear already exists in ProfileSheet).
+- **Workspace switch** → no wipe; data is namespaced by `feedKey` slug, switching back is instant.
+- **Startup prune** → delete feeds (and their photos) with `fetchedAt` older than 30 days, so unsubscribed galleries do not accumulate forever.
+- **SDWebImage** → configure `maxDiskSize = 512 MB`, `maxDiskAge = 60 days` (currently unlimited defaults).
+
+## Error handling
+
+- Offline with no cache → existing empty/error states with retry; unchanged.
+- Refresh failure over cache → silent; cache remains on screen.
+- Cached JSON decode failure (schema drift) → drop the row(s), fall through to network; never crash or blank on bad cache.
+- SwiftData migration failure → delete the store file and rebuild empty. The cache is reproducible data; the recovery path is always "act like a fresh install".
+
+## Testing
+
+- **Swift unit tests** (existing `native:test` harness): feed diff/upsert incl. reorder and deletion; 304 vs 200 refresh paths; 401 → wipe; network-failure → cached session retained; decode-failure fallback. Repository fake + mocked `AfilmoryAPI` boundary.
+- **Backend vitest** (`be/apps/core`): ETag stability for identical content, change on update, `If-None-Match` hit → 304 / miss → 200.
+- **Manual acceptance**: simulator cold start in airplane mode → photo grid renders, explore browsable, photo viewer shows cached images, user stays signed in; re-enable network → background refresh reconciles.


### PR DESCRIPTION
## Summary

Makes the iOS app offline-first: cold start renders the photo grid, explore page, and subscribed galleries from a local SwiftData cache with zero network round-trips, then revalidates in the background. Network failure can no longer sign the user out — only an explicit HTTP 401 does.

Design spec: `docs/superpowers/specs/2026-08-06-mobile-offline-cache-design.md` · Plan: `docs/superpowers/plans/2026-08-06-mobile-offline-cache-plan.md`

### What changed

- **Backend** — `GET /api/manifest` now sends a strong content-fingerprint `ETag` and honors `If-None-Match` → `304` with empty body (skips manifest serialization on the 304 path).
- **Persistence layer (new)** — `modules/photo-masonry/ios/Persistence/`: `AfilmoryDatabase` (self-healing ModelContainer in Application Support), four `@Model` classes (`CachedPhoto`/`CachedFeed`/`CachedGalleryDirectory`/`CachedSession`, JSON-payload columns), `PhotoCacheRepository` protocol with `@MainActor` sync reads + `ModelActor` writes, SwiftData impl + in-memory test fake. `@Model` types never leave the layer.
- **Photo feeds** — `PhotoFeedStore` is stale-while-revalidate: synchronous hydrate → immediate `.loaded` publish → conditional GET (`If-None-Match`, `URLCache` bypassed) → 304 touch / 200 diff-upsert-persist. Studio feed bypasses the cache. Subscribed galleries inherit caching via their `manifest:<slug>` feed keys.
- **Session** — native `AfilmorySessionStore` is the single session authority: cached synchronous bootstrap (Keychain cookie + persisted session), coalesced single in-flight refresh, retryable on foreground via `didBecomeActive`; network failure keeps state, 401 wipes cache + cookie. JS `sessionStore` is now a pure mirror over a new `AfilmorySessionModule` snapshot + change event — `hydrateAuth()` no longer fetches, and the old "offline → kicked to signed-out" defect is gone (`failed` is a distinct retryable visitor state).
- **Explore** — gallery directory cached via `GalleryDirectoryStore` (hydrate-then-refresh; search queries never persist).
- **Lifecycle** — once-per-launch background prune of feeds stale >30 days; SDWebImage capped at 512 MB / 60 days; sign-out and 401 wipe all cached data.

### Verification

- Native suite: **138/138** (57 new tests: repository round-trips/corruption/prune, SWR paths incl. an overlapping-loads race regression, session bootstrap/coalescing/401, directory cache, lifecycle once-guard)
- Backend: manifest vitest 7/7 (ETag stability, 304/200 paths)
- `pnpm --filter @afilmory/mobile type-check` + scoped lint: clean
- `expo export` bundle sanity: pass
- Simulator smoke (Release build, no Metro): explore tab renders signed-out with live directory data
- Airplane-mode cold-start acceptance on a signed-in device remains a manual TestFlight check (needs real credentials)

### Review process

Built task-by-task with per-task adversarial review + scoped re-review, then a whole-branch final review. The final review caught and this branch fixes two cross-task bugs: corrupted cache rows previously kept the feed ETag (304 loop could pin a broken grid), and search results could be persisted as the explore directory.

### Follow-ups (deliberately not in this PR)

Post-merge hardening batch triaged by the final review as non-blocking: wipe cache when publishing signed-out from the no-cookie Keychain edge, generation re-check after `saveSession`, cache-hydration retry for pre-first-unlock launches, `W/` weak-ETag tolerance in `matchesEtag`, dead-code deletions (`hasStoredNativeCookie`, unused test helper, shadowed `NSLock.withLock` extensions), surfacing `AuthState.error` as a retry affordance.