### PR TITLE
fix: remove custom domains after plan expiry

### DIFF
--- a/be/apps/core/src/modules/infrastructure/cloudflare/cloudflare-custom-hostname.service.spec.ts
+++ b/be/apps/core/src/modules/infrastructure/cloudflare/cloudflare-custom-hostname.service.spec.ts
@@ -129,4 +129,22 @@ describe('cloudflareCustomHostnameService', () => {
 
     await expect(service.create('photos.example.com')).rejects.toThrow('Zone does not have a fallback origin set.')
   })
+
+  it('treats an already deleted hostname as a successful idempotent deletion', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: false,
+          errors: [{ code: 1436, message: 'The custom hostname was not found.' }],
+        }),
+        { status: 404, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    await expect(service.delete('missing-hostname-id')).resolves.toBeUndefined()
+
+    const [url, request] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/custom_hostnames/missing-hostname-id')
+    expect(request.method).toBe('DELETE')
+  })
 })

--- a/be/apps/core/src/modules/infrastructure/cloudflare/cloudflare-custom-hostname.service.ts
+++ b/be/apps/core/src/modules/infrastructure/cloudflare/cloudflare-custom-hostname.service.ts
@@ -95,7 +95,10 @@ export class CloudflareCustomHostnameService {
   }
 
   async delete(customHostnameId: string): Promise<void> {
-    await this.request<unknown>(`/custom_hostnames/${customHostnameId}`, { method: 'DELETE' })
+    await this.request<unknown>(`/custom_hostnames/${customHostnameId}`, {
+      method: 'DELETE',
+      ignoreNotFound: true,
+    })
   }
 
   private getConfig(): CloudflareCustomHostnameConfig {
@@ -130,7 +133,11 @@ export class CloudflareCustomHostnameService {
 
   private async request<T>(
     path: string,
-    options: { method?: 'DELETE' | 'GET' | 'PATCH' | 'POST', body?: Record<string, unknown> } = {},
+    options: {
+      method?: 'DELETE' | 'GET' | 'PATCH' | 'POST'
+      body?: Record<string, unknown>
+      ignoreNotFound?: boolean
+    } = {},
   ): Promise<T> {
     const config = this.getConfig()
     const method = options.method ?? 'GET'
@@ -143,6 +150,10 @@ export class CloudflareCustomHostnameService {
       body: options.body ? JSON.stringify(options.body) : undefined,
       signal: AbortSignal.timeout(10_000),
     })
+
+    if (options.ignoreNotFound && response.status === 404) {
+      return undefined as T
+    }
 
     let payload: CloudflareApiResponse<T> | null = null
     try {

--- a/be/apps/core/src/modules/platform/auth/auth-provider.billing.spec.ts
+++ b/be/apps/core/src/modules/platform/auth/auth-provider.billing.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AuthProvider } from './auth.provider'
+
+interface CreemWebhookInvoker {
+  handleCreemWebhook: (params: {
+    event: string
+    metadata?: Record<string, unknown> | null
+    status?: string | null
+    forceRevoke?: boolean
+  }) => Promise<void>
+}
+
+function createProvider() {
+  const billingPlanService = {
+    updateTenantPlan: vi.fn().mockResolvedValue(undefined),
+  }
+  const storagePlanService = {
+    updateTenantPlan: vi.fn().mockResolvedValue(undefined),
+  }
+  const tenantDomainService = {
+    deleteDomainsForTenant: vi.fn().mockResolvedValue(1),
+  }
+  const provider = new AuthProvider(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    billingPlanService as never,
+    storagePlanService as never,
+    tenantDomainService as never,
+  )
+
+  return {
+    billingPlanService,
+    provider: provider as unknown as CreemWebhookInvoker,
+    tenantDomainService,
+  }
+}
+
+describe('authProvider billing revocation', () => {
+  it('deletes custom domains after an expired subscription downgrades the tenant', async () => {
+    const { billingPlanService, provider, tenantDomainService } = createProvider()
+
+    await provider.handleCreemWebhook({
+      event: 'subscription.expired',
+      metadata: { planId: 'pro', tenantId: 'tenant-1' },
+      status: 'expired',
+      forceRevoke: true,
+    })
+
+    expect(billingPlanService.updateTenantPlan).toHaveBeenCalledWith('tenant-1', 'free')
+    expect(tenantDomainService.deleteDomainsForTenant).toHaveBeenCalledWith('tenant-1')
+  })
+
+  it('propagates domain cleanup failures so the expired webhook can be retried', async () => {
+    const { provider, tenantDomainService } = createProvider()
+    tenantDomainService.deleteDomainsForTenant.mockRejectedValueOnce(new Error('Cloudflare unavailable'))
+
+    await expect(
+      provider.handleCreemWebhook({
+        event: 'subscription.expired',
+        metadata: { planId: 'pro', tenantId: 'tenant-1' },
+        status: 'expired',
+        forceRevoke: true,
+      }),
+    ).rejects.toThrow('Cloudflare unavailable')
+  })
+})

--- a/be/apps/core/src/modules/platform/auth/auth.provider.ts
+++ b/be/apps/core/src/modules/platform/auth/auth.provider.ts
@@ -16,6 +16,7 @@ import { BILLING_PLAN_IDS } from '@core/modules/platform/billing/billing-plan.co
 import { BillingPlanService } from '@core/modules/platform/billing/billing-plan.service'
 import type { BillingPlanId } from '@core/modules/platform/billing/billing-plan.types'
 import { StoragePlanService } from '@core/modules/platform/billing/storage-plan.service'
+import { TenantDomainService } from '@core/modules/platform/tenant/tenant-domain.service'
 import type { FlatSubscriptionEvent } from '@creem_io/better-auth'
 import { creem } from '@creem_io/better-auth'
 import type { OnModuleInit } from '@tsuki-hono/common'
@@ -61,6 +62,7 @@ export class AuthProvider implements OnModuleInit {
     private readonly appleClientSecrets: AppleClientSecretService,
     private readonly billingPlanService: BillingPlanService,
     private readonly storagePlanService: StoragePlanService,
+    private readonly tenantDomainService: TenantDomainService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -536,11 +538,13 @@ export class AuthProvider implements OnModuleInit {
   }): Promise<void> {
     const { tenantId, planId, storagePlanId, event } = params
     let handled = false
+    let shouldDeleteCustomDomains = false
 
     if (planId) {
       handled = true
       try {
         await this.billingPlanService.updateTenantPlan(tenantId, 'free')
+        shouldDeleteCustomDomains = true
         logger.info(`[AuthProvider] Tenant ${tenantId} downgraded to free via Creem (${event})`)
       }
       catch (error) {
@@ -556,6 +560,20 @@ export class AuthProvider implements OnModuleInit {
       }
       catch (error) {
         logger.error(`[AuthProvider] Failed to clear tenant ${tenantId} storage plan after Creem ${event}`, error)
+      }
+    }
+
+    if (shouldDeleteCustomDomains) {
+      try {
+        const deletedCount = await this.tenantDomainService.deleteDomainsForTenant(tenantId)
+        logger.info(`[AuthProvider] Deleted ${deletedCount} custom domains for tenant ${tenantId} after Creem ${event}`)
+      }
+      catch (error) {
+        logger.error(
+          `[AuthProvider] Failed to delete custom domains for tenant ${tenantId} after Creem ${event}`,
+          error,
+        )
+        throw error
       }
     }
 

--- a/be/apps/core/src/modules/platform/tenant/tenant-domain.service.spec.ts
+++ b/be/apps/core/src/modules/platform/tenant/tenant-domain.service.spec.ts
@@ -11,8 +11,10 @@ describe('tenantDomainService plan enforcement', () => {
   const repository = {
     countByTenant: vi.fn(),
     createDomain: vi.fn(),
+    deleteDomain: vi.fn(),
     findActiveByDomain: vi.fn(),
     findByDomain: vi.fn(),
+    listByTenant: vi.fn(),
   }
   const systemSettings = {
     getSettings: vi.fn(),
@@ -22,6 +24,7 @@ describe('tenantDomainService plan enforcement', () => {
   }
   const cloudflare = {
     createOrGet: vi.fn(),
+    delete: vi.fn(),
   }
   const billingPlanService = {
     ensureCustomDomainAllowance: vi.fn(),
@@ -41,6 +44,7 @@ describe('tenantDomainService plan enforcement', () => {
     repository.findByDomain.mockResolvedValue(null)
     repository.findActiveByDomain.mockResolvedValue(null)
     repository.countByTenant.mockResolvedValue(0)
+    repository.listByTenant.mockResolvedValue([])
     systemSettings.getSettings.mockResolvedValue({ baseDomain: 'afilmory.art' })
     billingPlanService.hasCustomDomainEntitlement.mockResolvedValue(true)
   })
@@ -80,5 +84,28 @@ describe('tenantDomainService plan enforcement', () => {
     billingPlanService.hasCustomDomainEntitlement.mockResolvedValue(false)
 
     await expect(service.resolveTenantByDomain('photos.example.net')).resolves.toBeNull()
+  })
+
+  it('deletes every Cloudflare hostname and local record when a tenant loses the plan entitlement', async () => {
+    repository.listByTenant.mockResolvedValue([
+      { id: 'domain-1', cloudflareHostnameId: 'cf-hostname-1' },
+      { id: 'domain-2', cloudflareHostnameId: null },
+    ])
+
+    await expect(service.deleteDomainsForTenant('tenant-1')).resolves.toBe(2)
+
+    expect(cloudflare.delete).toHaveBeenCalledOnce()
+    expect(cloudflare.delete).toHaveBeenCalledWith('cf-hostname-1')
+    expect(repository.deleteDomain).toHaveBeenNthCalledWith(1, 'domain-1')
+    expect(repository.deleteDomain).toHaveBeenNthCalledWith(2, 'domain-2')
+  })
+
+  it('keeps the local record when Cloudflare deletion fails so a webhook retry can finish cleanup', async () => {
+    repository.listByTenant.mockResolvedValue([{ id: 'domain-1', cloudflareHostnameId: 'cf-hostname-1' }])
+    cloudflare.delete.mockRejectedValueOnce(new Error('Cloudflare unavailable'))
+
+    await expect(service.deleteDomainsForTenant('tenant-1')).rejects.toThrow('Cloudflare unavailable')
+
+    expect(repository.deleteDomain).not.toHaveBeenCalled()
   })
 })

--- a/be/apps/core/src/modules/platform/tenant/tenant-domain.service.ts
+++ b/be/apps/core/src/modules/platform/tenant/tenant-domain.service.ts
@@ -127,10 +127,16 @@ export class TenantDomainService {
     if (aggregate.tenant.id !== tenantContext.tenant.id) {
       throw new BizException(ErrorCode.COMMON_FORBIDDEN, { message: '无法操作其他空间的域名' })
     }
-    if (aggregate.domain.cloudflareHostnameId) {
-      await this.cloudflare.delete(aggregate.domain.cloudflareHostnameId)
+
+    await this.deleteDomainRecord(aggregate.domain)
+  }
+
+  async deleteDomainsForTenant(tenantId: string): Promise<number> {
+    const domains = await this.repository.listByTenant(tenantId)
+    for (const domain of domains) {
+      await this.deleteDomainRecord(domain)
     }
-    await this.repository.deleteDomain(domainId)
+    return domains.length
   }
 
   private normalizeDomain(value?: string | null): string | null {
@@ -158,6 +164,13 @@ export class TenantDomainService {
 
     const cloudflareHostname = await this.cloudflare.createOrGet(aggregate.domain.domain)
     return await this.syncCloudflareState(aggregate.domain.id, cloudflareHostname)
+  }
+
+  private async deleteDomainRecord(domain: TenantDomainRecord): Promise<void> {
+    if (domain.cloudflareHostnameId) {
+      await this.cloudflare.delete(domain.cloudflareHostnameId)
+    }
+    await this.repository.deleteDomain(domain.id)
   }
 
   private async syncCloudflareState(


### PR DESCRIPTION
## Summary

- delete every Cloudflare Custom Hostname and local tenant-domain record after a paid plan is revoked
- propagate cleanup failures so Creem can retry the expiration webhook
- treat Cloudflare 404 responses as successful idempotent deletions
- add regression coverage for the expiration hook, cleanup ordering, retry safety, and idempotent provider deletion

## Why

Tenants lost custom-domain routing when their Pro entitlement expired, but the Cloudflare hostname and local domain record remained allocated. This leaked provider-side resources and retained stale bindings.

## Validation

- `pnpm exec vitest run` — 22 files, 79 tests passed
- targeted ESLint — passed
- `pnpm run build` for `@afilmory/core` — passed
- standalone `tsc --noEmit` is currently blocked by the repository resolving TypeScript 5.9.3 while `ignoreDeprecations` is configured for 6.0
