### PR TITLE
feat(web): add telemetry.vibeloft opt-out config

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -24,12 +24,15 @@
       window.__SITE_CONFIG__ = {}
     </script>
     <script id="manifest"></script>
+    <% if (vibeloft) { %>
+    <!-- VibeLoft 页面浏览遥测（可通过 config.json 的 telemetry.vibeloft 关闭） -->
     <script
       defer
       src="https://vibeloft.ai/telemetry/v1.js"
       data-vl-product-id="e99696d9-d5af-492b-8768-67d12f09af2c"
       data-vl-auth-key="vl_web.cXoOzToLqG2I4TrBn6p0KViwbFjw3DhQ0AWkGp5Xixs"
     ></script>
+    <% } %>
   </head>
   <body>
     <div id="root">

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -166,6 +166,7 @@ const staticWebBuildPlugins: PluginOption[] = [
       data: {
         title: siteConfig.title,
         description: siteConfig.description,
+        vibeloft: siteConfig.telemetry?.vibeloft !== false,
       },
     },
   }),

--- a/config.example.json
+++ b/config.example.json
@@ -26,6 +26,9 @@
   ],
   "mapStyle": "builtin",
   "mapProjection": "mercator",
+  "telemetry": {
+    "vibeloft": true
+  },
   "beian": {
     "icp": {
       "enabled": false,

--- a/site.config.ts
+++ b/site.config.ts
@@ -15,6 +15,19 @@ export interface SiteConfig {
   mapStyle?: string
   mapProjection?: 'globe' | 'mercator'
   beian?: BeianConfig
+  /** 第三方遥测配置 */
+  telemetry?: TelemetryConfig
+}
+
+/**
+ * 第三方遥测配置
+ */
+interface TelemetryConfig {
+  /**
+   * 是否启用 VibeLoft 页面浏览遥测（https://vibeloft.ai）。
+   * 默认开启；自托管站点可通过 `"telemetry": { "vibeloft": false }` 关闭。
+   */
+  vibeloft?: boolean
 }
 
 /**
@@ -88,6 +101,9 @@ const defaultConfig: SiteConfig = {
     name: 'Afilmory',
     url: 'https://afilmory.art/',
     avatar: 'https://cdn.jsdelivr.net/gh/Afilmory/Afilmory@main/logo.jpg',
+  },
+  telemetry: {
+    vibeloft: true,
   },
 }
 export const siteConfig: SiteConfig = merge(defaultConfig, userConfig) as any


### PR DESCRIPTION
VibeLoft page-view telemetry (vibeloft.ai) was hardcoded in apps/web/index.html with no way to disable it. Add a site config option:
```
  "telemetry": { "vibeloft": false }
```
which excludes the telemetry script from the built HTML. Defaults to enabled, preserving current behavior.