### PR TITLE
feat(web): add telemetry.vibeloft opt-out for VibeLoft script

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -24,12 +24,7 @@
       window.__SITE_CONFIG__ = {}
     </script>
     <script id="manifest"></script>
-    <script
-      defer
-      src="https://vibeloft.ai/telemetry/v1.js"
-      data-vl-product-id="e99696d9-d5af-492b-8768-67d12f09af2c"
-      data-vl-auth-key="vl_web.cXoOzToLqG2I4TrBn6p0KViwbFjw3DhQ0AWkGp5Xixs"
-    ></script>
+    <!-- vibeloft-telemetry -->
   </head>
   <body>
     <div id="root">

--- a/apps/web/plugins/vite/vibeloft-telemetry.ts
+++ b/apps/web/plugins/vite/vibeloft-telemetry.ts
@@ -1,0 +1,38 @@
+import type { Plugin } from 'vite'
+
+import { siteConfig } from '../../../../site.config'
+
+/** index.html 中的注释占位符,构建时由本插件替换为遥测脚本或移除 */
+const TELEMETRY_PLACEHOLDER = '<!-- vibeloft-telemetry -->'
+
+const TELEMETRY_SCRIPT = `<script
+      id="vibeloft-telemetry"
+      defer
+      src="https://vibeloft.ai/telemetry/v1.js"
+      data-vl-product-id="e99696d9-d5af-492b-8768-67d12f09af2c"
+      data-vl-auth-key="vl_web.cXoOzToLqG2I4TrBn6p0KViwbFjw3DhQ0AWkGp5Xixs"
+    ></script>`
+
+/**
+ * VibeLoft 遥测 opt-out 插件。
+ *
+ * 与 manifest-inject 一样用字符串替换处理 index.html:
+ * - enabled(默认):把 `<!-- vibeloft-telemetry -->` 占位注释替换为遥测脚本
+ * - disabled(config.json 设置 telemetry.vibeloft: false):占位注释替换为空,产物完全不含遥测
+ * 静态与 server-serve 构建都会执行(SaaS 默认按仓库 config.json 保留脚本)。
+ */
+export function vibeloftTelemetryPlugin(): Plugin {
+  const enabled = siteConfig.telemetry?.vibeloft !== false
+
+  return {
+    name: 'vibeloft-telemetry',
+
+    transformIndexHtml(html) {
+      if (enabled) {
+        return html.replace(TELEMETRY_PLACEHOLDER, TELEMETRY_SCRIPT)
+      }
+
+      return html.replace(TELEMETRY_PLACEHOLDER, '')
+    },
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,6 +27,7 @@ import { manifestInjectPlugin } from './plugins/vite/manifest-inject'
 import { ogImagePlugin } from './plugins/vite/og-image-plugin'
 import { photosStaticPlugin } from './plugins/vite/photos-static'
 import { siteConfigInjectPlugin } from './plugins/vite/site-config-inject'
+import { vibeloftTelemetryPlugin } from './plugins/vite/vibeloft-telemetry'
 
 const devPrint = (): PluginOption => ({
   name: 'dev-print',
@@ -213,6 +214,7 @@ export default defineConfig(() => {
       localesJsonPlugin(),
       tailwindcss(),
       ...(BUILD_FOR_SERVER_SERVE ? [] : staticWebBuildPlugins),
+      vibeloftTelemetryPlugin(),
       process.env.analyzer && analyzer(),
 
       devPrint(),

--- a/config.example.json
+++ b/config.example.json
@@ -38,5 +38,8 @@
       "code": "xxxxxxxxxxxxxx",
       "icon": "https://example.com/beian.png"
     }
+  },
+  "telemetry": {
+    "vibeloft": true
   }
 }

--- a/site.config.ts
+++ b/site.config.ts
@@ -15,6 +15,9 @@ export interface SiteConfig {
   mapStyle?: string
   mapProjection?: 'globe' | 'mercator'
   beian?: BeianConfig
+  telemetry?: {
+    vibeloft?: boolean
+  }
 }
 
 /**
@@ -88,6 +91,9 @@ const defaultConfig: SiteConfig = {
     name: 'Afilmory',
     url: 'https://afilmory.art/',
     avatar: 'https://cdn.jsdelivr.net/gh/Afilmory/Afilmory@main/logo.jpg',
+  },
+  telemetry: {
+    vibeloft: true,
   },
 }
 export const siteConfig: SiteConfig = merge(defaultConfig, userConfig) as any


### PR DESCRIPTION
VibeLoft 遥测 opt-out,注释占位 + 字符串替换(manifest-inject 同款):

- index.html 只留注释占位 `<!-- vibeloft-telemetry -->`
- 新增 `vibeloftTelemetryPlugin`:构建时把占位注释替换成遥测 script(默认)或替换为空(`"telemetry": { "vibeloft": false }`)
- 静态与 server-serve 构建都会执行:SaaS 默认保留脚本,关闭需要仓库 `config.json` 显式配置
- 不引入 EJS,createHtmlPlugin 不动