### PR TITLE
fix: add App Review UGC safety controls

### DIFF
--- a/apps/mobile/Afilmory.xcodeproj/project.pbxproj
+++ b/apps/mobile/Afilmory.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		8D9F3DE4B056BDD68C21E34B /* PhotoInfoSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D335F66C041584D86C64B7 /* PhotoInfoSheetView.swift */; };
 		8F438DB65CC420934C08C060 /* ShareUploadIntentBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D82DE36F8871D52C3064458 /* ShareUploadIntentBridge.swift */; };
 		90A71B24DAAF9EA34EF4C2BE /* QuotaWarningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFCC01D6A33BE847EF73BFA /* QuotaWarningCell.swift */; };
+		9221F7D4D1C2FA7B1EF3051D /* CommentModerationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A48B0DB157451DB66B9094 /* CommentModerationModels.swift */; };
 		93635EFE19F9CA10EB391A34 /* SubscriptionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1EE9D94CC320E80A87FD609 /* SubscriptionStore.swift */; };
 		93961EB3861FF96242456FE9 /* PhotoDetailReactionHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57F414A207E399C72D55EF9 /* PhotoDetailReactionHaptics.swift */; };
 		945FFDEA3BF4BBCECF633483 /* PhotoShareLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71FF619CFBFE649AE9204C1 /* PhotoShareLinkTests.swift */; };
@@ -390,6 +391,7 @@
 		4D04B2B515EB956A72E8BB09 /* app-zh-CN.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "app-zh-CN.json"; sourceTree = "<group>"; };
 		4E22F890E2D228D7A8F9CFB0 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		4E35A937CC6426DA98BB7CFE /* ApiEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiEnvironment.swift; sourceTree = "<group>"; };
+		50A48B0DB157451DB66B9094 /* CommentModerationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentModerationModels.swift; sourceTree = "<group>"; };
 		56A0F0A9F03A8EC23C36CF49 /* NativeAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAuthenticationService.swift; sourceTree = "<group>"; };
 		594FD17F4B5F060DAA97F9AC /* Afilmory.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Afilmory.entitlements; sourceTree = "<group>"; };
 		597E840019CB57F11FA0133D /* DeveloperLabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperLabView.swift; sourceTree = "<group>"; };
@@ -1098,6 +1100,7 @@
 				74393CACCCF96E326A5E22EB /* CommentComposerView.swift */,
 				E33142E7ED743BCFCEA9826A /* CommentInlineErrorView.swift */,
 				E52962F1ECE5CC9B8BD0036E /* CommentModels.swift */,
+				50A48B0DB157451DB66B9094 /* CommentModerationModels.swift */,
 				C47FB592E13AB4CA590934F3 /* CommentRowView.swift */,
 				F874A7AA3AC08DE73918EC48 /* CommentsAPI.swift */,
 				BC7901F977378EBC9E70FCFE /* CommentSendFlightView.swift */,
@@ -1384,6 +1387,7 @@
 				DD0B349C84685E07B9962193 /* CommentComposerView.swift in Sources */,
 				DD5703DD55AD21C0BDDBA519 /* CommentInlineErrorView.swift in Sources */,
 				C35E0E9C1EE9A1B2EC87DE60 /* CommentModels.swift in Sources */,
+				9221F7D4D1C2FA7B1EF3051D /* CommentModerationModels.swift in Sources */,
 				64A38340465CF553FD40A62F /* CommentRowView.swift in Sources */,
 				624055D31A4E73267A917FB5 /* CommentSendFlightView.swift in Sources */,
 				582633C883FE84C3628C907E /* CommentSignInView.swift in Sources */,

--- a/apps/mobile/NativeApp/App/ApplicationCoordinator.swift
+++ b/apps/mobile/NativeApp/App/ApplicationCoordinator.swift
@@ -250,6 +250,10 @@ final class ApplicationCoordinator: NSObject, UNUserNotificationCenterDelegate {
       }
     case .developerLab:
       #if DEBUG
+        if let navigation = window.rootViewController as? UINavigationController {
+          presentDeveloperLab(on: navigation)
+          return
+        }
         guard let tabs = window.rootViewController as? AfilmoryTabBarController,
               let navigation = tabs.viewControllers?[safe: 3] as? UINavigationController
         else { return }

--- a/apps/mobile/NativeApp/Authentication/SignInView.swift
+++ b/apps/mobile/NativeApp/Authentication/SignInView.swift
@@ -27,6 +27,7 @@ struct SignInView: View {
   @State private var busyAction: SignInBusyAction?
   @State private var email = ""
   @State private var error: String?
+  @State private var hasAcceptedLegalTerms = false
   @State private var password = ""
   @State private var showPasswordForm = false
 
@@ -104,7 +105,10 @@ struct SignInView: View {
         .font(.system(size: 14))
         .foregroundStyle(.secondary)
         .padding(.top, 4)
-        .padding(.bottom, 20)
+        .padding(.bottom, 14)
+
+      legalAgreement
+        .padding(.bottom, 16)
 
       VStack(spacing: 10) {
         if AfilmoryBuildConfiguration.supportsAppleAuthentication {
@@ -117,8 +121,9 @@ struct SignInView: View {
                 try await authentication.signInWithApple(anchor: anchor)
               }
             }
-            .opacity(busyAction == nil || busyAction == .apple ? 1 : 0.45)
-            .allowsHitTesting(busyAction == nil)
+            .opacity((busyAction == nil || busyAction == .apple) && hasAcceptedLegalTerms ? 1 : 0.45)
+            .allowsHitTesting(busyAction == nil && hasAcceptedLegalTerms)
+            .disabled(busyAction != nil || !hasAcceptedLegalTerms)
             if busyAction == .apple {
               RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(.white)
@@ -150,7 +155,7 @@ struct SignInView: View {
             .frame(maxWidth: .infinity, minHeight: 32)
         }
         .buttonStyle(.plain)
-        .disabled(busyAction != nil)
+        .disabled(busyAction != nil || !hasAcceptedLegalTerms)
         .accessibilityIdentifier("auth.email.toggle")
 
         if showPasswordForm {
@@ -173,6 +178,24 @@ struct SignInView: View {
         }
       }
     }
+  }
+
+  private var legalAgreement: some View {
+    Toggle(isOn: $hasAcceptedLegalTerms) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("I agree to Afilmory's Terms of Use and Privacy Policy.")
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.primary)
+        HStack(spacing: 12) {
+          Link(String(localized: "Terms of Use"), destination: URL(string: "https://afilmory.art/terms/")!)
+          Link(String(localized: "Privacy Policy"), destination: URL(string: "https://afilmory.art/privacy/")!)
+        }
+        .font(.system(size: 12, weight: .semibold))
+      }
+    }
+    .toggleStyle(.switch)
+    .tint(Color(red: 0, green: 123 / 255, blue: 1))
+    .accessibilityIdentifier("auth.legalAgreement")
   }
 
   private func providerButton(
@@ -222,8 +245,8 @@ struct SignInView: View {
       .contentShape(.rect)
     }
     .buttonStyle(.plain)
-    .disabled(busyAction != nil)
-    .opacity(busyAction == nil || busyAction == action ? 1 : 0.45)
+    .disabled(busyAction != nil || !hasAcceptedLegalTerms)
+    .opacity((busyAction == nil || busyAction == action) && hasAcceptedLegalTerms ? 1 : 0.45)
     .accessibilityIdentifier(action == .github ? "auth.github" : "auth.google")
   }
 
@@ -262,7 +285,7 @@ struct SignInView: View {
         .clipShape(.rect(cornerRadius: 22, style: .continuous))
       }
       .buttonStyle(.plain)
-      .disabled(busyAction != nil)
+      .disabled(busyAction != nil || !hasAcceptedLegalTerms)
       Text("Email sign-in is available for invited and App Review accounts. New public accounts use a social provider.")
         .font(.system(size: 12))
         .foregroundStyle(.tertiary)
@@ -292,6 +315,10 @@ struct SignInView: View {
   }
 
   private func submitPassword() {
+    guard hasAcceptedLegalTerms else {
+      error = String(localized: "Agree to the Terms of Use and Privacy Policy before signing in.")
+      return
+    }
     let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedEmail.isEmpty, !password.isEmpty else {
       error = String(localized: "Enter both email and password.")
@@ -307,6 +334,10 @@ struct SignInView: View {
     operation: @escaping @MainActor () async throws -> Void
   ) {
     guard busyAction == nil else { return }
+    guard hasAcceptedLegalTerms else {
+      error = String(localized: "Agree to the Terms of Use and Privacy Policy before signing in.")
+      return
+    }
     busyAction = action
     error = nil
     Task { @MainActor in

--- a/apps/mobile/NativeApp/Design/NativeControls.swift
+++ b/apps/mobile/NativeApp/Design/NativeControls.swift
@@ -36,6 +36,8 @@ struct AfilmoryButton<Label: View>: View {
 }
 
 struct NativeAppleAuthorizationButton: UIViewRepresentable {
+  @Environment(\.isEnabled) private var isEnabled
+
   let type: ASAuthorizationAppleIDButton.ButtonType
   let action: () -> Void
 
@@ -46,11 +48,13 @@ struct NativeAppleAuthorizationButton: UIViewRepresentable {
   func makeUIView(context: Context) -> ASAuthorizationAppleIDButton {
     let button = ASAuthorizationAppleIDButton(authorizationButtonType: type, authorizationButtonStyle: .white)
     button.cornerRadius = 14
+    button.isEnabled = isEnabled
     button.addTarget(context.coordinator, action: #selector(Coordinator.invoke), for: .touchUpInside)
     return button
   }
 
-  func updateUIView(_: ASAuthorizationAppleIDButton, context: Context) {
+  func updateUIView(_ button: ASAuthorizationAppleIDButton, context: Context) {
+    button.isEnabled = isEnabled
     context.coordinator.action = action
   }
 

--- a/apps/mobile/modules/photo-masonry/ios/Comments/CommentModerationModels.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/CommentModerationModels.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum CommentReportReason: String, CaseIterable, Encodable, Identifiable {
+  case spam
+  case harassment
+  case hateOrViolence = "hate_or_violence"
+  case sexualContent = "sexual_content"
+  case other
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .spam: String(localized: "Spam")
+    case .harassment: String(localized: "Harassment")
+    case .hateOrViolence: String(localized: "Hate or violence")
+    case .sexualContent: String(localized: "Sexual content")
+    case .other: String(localized: "Other")
+    }
+  }
+}
+
+struct CommentModerationBody: Encodable {
+  let reason: String
+  let details: String?
+}
+
+struct CommentReportResponse: Decodable {
+  let reportId: String
+  let reported: Bool
+  let status: String
+}
+
+struct CommentBlockResponse: Decodable {
+  let blocked: Bool
+  let blockedUserId: String
+  let reported: Bool
+}
+

--- a/apps/mobile/modules/photo-masonry/ios/Comments/CommentRowView.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/CommentRowView.swift
@@ -8,6 +8,8 @@ struct CommentRowView: View {
 
   @Environment(\.openURL) private var openURL
   @Environment(\.displayScale) private var displayScale
+  @State private var confirmingBlock = false
+  @State private var showingReportReasons = false
 
   private var own: Bool { comment.userId == store.viewerUserId }
   private var user: CommentUser? { store.user(for: comment) }
@@ -16,6 +18,7 @@ struct CommentRowView: View {
   private var likeCount: Int { comment.reactionCounts["like"] ?? 0 }
   private var liked: Bool { comment.viewerReactions.contains("like") }
   private var reactionBusy: Bool { store.pendingReactionIds.contains(comment.id) }
+  private var moderationBusy: Bool { store.pendingModerationIds.contains(comment.id) }
   private var isSending: Bool { comment.deliveryState == .sending }
   private var isFlightTarget: Bool { store.flight?.clientId == comment.identity }
 
@@ -52,6 +55,48 @@ struct CommentRowView: View {
       Button(String(localized: "Copy"), systemImage: "document.on.document") {
         UIPasteboard.general.string = comment.content
       }
+
+      if !own, !isSending {
+        Divider()
+        Button(String(localized: "Report Comment"), systemImage: "exclamationmark.bubble") {
+          showingReportReasons = true
+        }
+        .disabled(moderationBusy)
+        Button(
+          String(localized: "Block User"),
+          systemImage: "person.crop.circle.badge.xmark",
+          role: .destructive
+        ) {
+          confirmingBlock = true
+        }
+        .disabled(moderationBusy)
+      }
+    }
+    .confirmationDialog(
+      String(localized: "Why are you reporting this comment?"),
+      isPresented: $showingReportReasons,
+      titleVisibility: .visible
+    ) {
+      ForEach(CommentReportReason.allCases) { reason in
+        Button(reason.title) {
+          Task { await store.report(comment, reason: reason) }
+        }
+      }
+      Button(String(localized: "Cancel"), role: .cancel) {}
+    } message: {
+      Text(String(localized: "The report will be sent to the Afilmory moderation team."))
+    }
+    .confirmationDialog(
+      String(localized: "Block \(author)?"),
+      isPresented: $confirmingBlock,
+      titleVisibility: .visible
+    ) {
+      Button(String(localized: "Block User"), role: .destructive) {
+        Task { await store.blockAuthor(comment) }
+      }
+      Button(String(localized: "Cancel"), role: .cancel) {}
+    } message: {
+      Text(String(localized: "Their comments and galleries will be removed from your view immediately. This comment will also be reported to Afilmory."))
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(accessibilityLabel)
@@ -65,6 +110,14 @@ struct CommentRowView: View {
     }
     .accessibilityAction(named: Text(String(localized: "Copy"))) {
       UIPasteboard.general.string = comment.content
+    }
+    .accessibilityAction(named: Text(String(localized: "Report Comment"))) {
+      guard !own, !isSending, !moderationBusy else { return }
+      showingReportReasons = true
+    }
+    .accessibilityAction(named: Text(String(localized: "Block User"))) {
+      guard !own, !isSending, !moderationBusy else { return }
+      confirmingBlock = true
     }
   }
 
@@ -182,6 +235,9 @@ struct CommentRowView: View {
 
       likeButton
       replyButton
+      if !own {
+        moderationMenu
+      }
     }
     .frame(minHeight: 26)
     .padding(own ? .trailing : .leading, 3)
@@ -236,6 +292,38 @@ struct CommentRowView: View {
     .disabled(isSending)
     .opacity(isSending ? 0.38 : 1)
     .accessibilityLabel(String(localized: "Reply"))
+  }
+
+  private var moderationMenu: some View {
+    Menu {
+      Button(String(localized: "Report Comment"), systemImage: "exclamationmark.bubble") {
+        showingReportReasons = true
+      }
+      Button(
+        String(localized: "Block User"),
+        systemImage: "person.crop.circle.badge.xmark",
+        role: .destructive
+      ) {
+        confirmingBlock = true
+      }
+    } label: {
+      Group {
+        if moderationBusy {
+          ProgressView()
+            .controlSize(.mini)
+        } else {
+          Image(systemName: "ellipsis")
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.secondary)
+        }
+      }
+      .frame(width: 28, height: 26)
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .disabled(isSending || moderationBusy)
+    .accessibilityLabel(String(localized: "Comment safety actions"))
+    .accessibilityIdentifier("comments.moderation.\(comment.id)")
   }
 
   private var profileURL: URL? {

--- a/apps/mobile/modules/photo-masonry/ios/Comments/CommentsAPI.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/CommentsAPI.swift
@@ -49,4 +49,33 @@ enum CommentsAPI {
       body: try APIEndpoint.jsonBody(CommentReactionBody(reaction: reaction))
     )
   }
+
+  static func report(
+    baseURL: String,
+    commentId: String,
+    reason: CommentReportReason
+  ) throws -> APIEndpoint {
+    APIEndpoint(
+      baseURL: .explicit(baseURL),
+      path: "/comments/\(commentId)/reports",
+      method: .post,
+      body: try APIEndpoint.jsonBody(
+        CommentModerationBody(reason: reason.rawValue, details: nil)
+      )
+    )
+  }
+
+  static func blockAuthor(
+    baseURL: String,
+    commentId: String
+  ) throws -> APIEndpoint {
+    APIEndpoint(
+      baseURL: .explicit(baseURL),
+      path: "/comments/\(commentId)/block-author",
+      method: .post,
+      body: try APIEndpoint.jsonBody(
+        CommentModerationBody(reason: "abusive_behavior", details: nil)
+      )
+    )
+  }
 }

--- a/apps/mobile/modules/photo-masonry/ios/Comments/CommentsState.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/CommentsState.swift
@@ -68,6 +68,17 @@ enum CommentsState {
     return next
   }
 
+  static func removingAuthor(
+    _ current: CommentCollection,
+    userId: String
+  ) -> CommentCollection {
+    var next = current
+    next.comments.removeAll { $0.userId == userId }
+    next.relations = next.relations.filter { $0.value.userId != userId }
+    next.users.removeValue(forKey: userId)
+    return next
+  }
+
   static func advanceCursor(
     current: String?,
     page: CommentPage,

--- a/apps/mobile/modules/photo-masonry/ios/Comments/CommentsStore.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/CommentsStore.swift
@@ -33,7 +33,10 @@ final class CommentsStore {
   var draft = ""
   var replyCommentId: String?
   var pendingReactionIds: Set<String> = []
+  var pendingModerationIds: Set<String> = []
   var requiresAuthentication = false
+  var moderationNotice: String?
+  var showingModerationNotice = false
   var flight: CommentFlight?
   var pendingScrollIdentity: String?
   private(set) var requestedSignIn = false
@@ -44,6 +47,7 @@ final class CommentsStore {
   @ObservationIgnored private var flightLocked = false
   @ObservationIgnored private var baselineCommentCount: Int?
   @ObservationIgnored private var successfulCreateCount = 0
+  @ObservationIgnored private var successfulRemovalCount = 0
 
   init(
     request: PhotoCommentsSheetRequest,
@@ -70,7 +74,7 @@ final class CommentsStore {
   var result: PhotoCommentsSheetResult {
     let baseline = baselineCommentCount ?? max(0, collection.comments.count - successfulCreateCount)
     return PhotoCommentsSheetResult(
-      commentCount: max(0, baseline + successfulCreateCount),
+      commentCount: max(0, baseline + successfulCreateCount - successfulRemovalCount),
       requestedSignIn: requestedSignIn
     )
   }
@@ -227,6 +231,65 @@ final class CommentsStore {
       }
     }
     pendingReactionIds.remove(commentId)
+  }
+
+  func report(_ comment: CommentItem, reason: CommentReportReason) async {
+    guard isSignedIn else {
+      requestSignIn()
+      return
+    }
+    guard comment.userId != viewerUserId,
+          comment.deliveryState != .sending,
+          !pendingModerationIds.contains(comment.id)
+    else { return }
+
+    pendingModerationIds.insert(comment.id)
+    inlineError = nil
+    defer { pendingModerationIds.remove(comment.id) }
+
+    do {
+      _ = try await transport.report(commentId: comment.id, reason: reason)
+      moderationNotice = String(localized: "Report submitted. Our moderation team has been notified.")
+      showingModerationNotice = true
+    } catch {
+      if !handleUnauthorized(error), !isCancellation(error) {
+        inlineError = String(localized: "Unable to submit the report. Try again.")
+      }
+    }
+  }
+
+  func blockAuthor(_ comment: CommentItem) async {
+    guard isSignedIn else {
+      requestSignIn()
+      return
+    }
+    guard comment.userId != viewerUserId,
+          comment.deliveryState != .sending,
+          !pendingModerationIds.contains(comment.id)
+    else { return }
+
+    let previous = collection
+    let removedCount = collection.comments.count { $0.userId == comment.userId }
+    pendingModerationIds.insert(comment.id)
+    inlineError = nil
+    mutateAnimated {
+      collection = CommentsState.removingAuthor(collection, userId: comment.userId)
+    }
+
+    do {
+      _ = try await transport.blockAuthor(commentId: comment.id)
+      successfulRemovalCount += removedCount
+      moderationNotice = String(localized: "User blocked. Their content was removed.")
+      showingModerationNotice = true
+    } catch {
+      mutateAnimated {
+        collection = previous
+      }
+      if !handleUnauthorized(error), !isCancellation(error) {
+        inlineError = String(localized: "Unable to block this user. Try again.")
+      }
+    }
+    pendingModerationIds.remove(comment.id)
   }
 
   func beginReply(to comment: CommentItem) {

--- a/apps/mobile/modules/photo-masonry/ios/Comments/CommentsTransport.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/CommentsTransport.swift
@@ -4,6 +4,8 @@ protocol CommentsTransport: Sendable {
   func list(photoId: String, cursor: String?) async throws -> CommentPage
   func create(content: String, photoId: String, parentId: String?) async throws -> CommentPage
   func toggleReaction(commentId: String) async throws -> CommentReactionResponse
+  func report(commentId: String, reason: CommentReportReason) async throws -> CommentReportResponse
+  func blockAuthor(commentId: String) async throws -> CommentBlockResponse
 }
 
 struct LiveCommentsTransport: CommentsTransport {
@@ -27,6 +29,14 @@ struct LiveCommentsTransport: CommentsTransport {
 
   func toggleReaction(commentId: String) async throws -> CommentReactionResponse {
     try await api.request(CommentsAPI.toggleReaction(baseURL: baseURL, commentId: commentId))
+  }
+
+  func report(commentId: String, reason: CommentReportReason) async throws -> CommentReportResponse {
+    try await api.request(CommentsAPI.report(baseURL: baseURL, commentId: commentId, reason: reason))
+  }
+
+  func blockAuthor(commentId: String) async throws -> CommentBlockResponse {
+    try await api.request(CommentsAPI.blockAuthor(baseURL: baseURL, commentId: commentId))
   }
 }
 
@@ -115,6 +125,32 @@ actor DemoCommentsTransport: CommentsTransport {
     toggled.deliveryState = nil
     items[commentId] = toggled
     return CommentReactionResponse(item: toggled)
+  }
+
+  func report(commentId: String, reason _: CommentReportReason) async throws -> CommentReportResponse {
+    try await Task.sleep(for: .milliseconds(250))
+    if outcome == .failure {
+      throw APIError.http(status: 500, body: "Simulated report failure.")
+    }
+    guard items[commentId] != nil else {
+      throw APIError.http(status: 404, body: nil)
+    }
+    return CommentReportResponse(reportId: "demo-report-\(commentId)", reported: true, status: "pending")
+  }
+
+  func blockAuthor(commentId: String) async throws -> CommentBlockResponse {
+    try await Task.sleep(for: .milliseconds(250))
+    if outcome == .failure {
+      throw APIError.http(status: 500, body: "Simulated block failure.")
+    }
+    guard let item = items[commentId] else {
+      throw APIError.http(status: 404, body: nil)
+    }
+    let blockedUserId = item.userId
+    order.removeAll { items[$0]?.userId == blockedUserId }
+    items = items.filter { $0.value.userId != blockedUserId }
+    users.removeValue(forKey: blockedUserId)
+    return CommentBlockResponse(blocked: true, blockedUserId: blockedUserId, reported: true)
   }
 
   private func page(for comments: [CommentItem]) -> CommentPage {

--- a/apps/mobile/modules/photo-masonry/ios/Comments/PhotoCommentsSheetView.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Comments/PhotoCommentsSheetView.swift
@@ -30,6 +30,16 @@ struct PhotoCommentsSheetView: View {
       .task {
         await store.loadInitial()
       }
+      .alert(
+        String(localized: "Content safety"),
+        isPresented: $store.showingModerationNotice
+      ) {
+        Button(String(localized: "Done"), role: .cancel) {}
+      } message: {
+        if let moderationNotice = store.moderationNotice {
+          Text(moderationNotice)
+        }
+      }
   }
 
   @ViewBuilder private var content: some View {

--- a/apps/mobile/modules/photo-masonry/ios/Tests/CommentsStateTests.swift
+++ b/apps/mobile/modules/photo-masonry/ios/Tests/CommentsStateTests.swift
@@ -67,6 +67,26 @@ final class CommentsStateTests: XCTestCase {
     XCTAssertEqual(unliked.viewerReactions, [])
   }
 
+  func testRemovingBlockedAuthorRemovesAllOfTheirCommentsRelationsAndProfile() {
+    let blocked = comment(id: "blocked-one", userId: "blocked")
+    let visible = comment(id: "visible", userId: "visible")
+    let current = CommentCollection(
+      comments: [blocked, visible, comment(id: "blocked-two", userId: "blocked")],
+      relations: ["blocked-parent": comment(id: "blocked-parent", userId: "blocked")],
+      users: [
+        "blocked": CommentUser(id: "blocked", name: "Blocked", image: nil, website: nil),
+        "visible": CommentUser(id: "visible", name: "Visible", image: nil, website: nil),
+      ]
+    )
+
+    let result = CommentsState.removingAuthor(current, userId: "blocked")
+
+    XCTAssertEqual(result.comments.map(\.id), ["visible"])
+    XCTAssertNil(result.relations["blocked-parent"])
+    XCTAssertNil(result.users["blocked"])
+    XCTAssertEqual(result.users["visible"]?.name, "Visible")
+  }
+
   func testCursorAdvancesFromTheIncomingPage() {
     let page = CommentPage(
       comments: [comment(id: "next")],
@@ -88,12 +108,12 @@ final class CommentsStateTests: XCTestCase {
     XCTAssertEqual(status, 403)
   }
 
-  private func comment(id: String, content: String? = nil) -> CommentItem {
+  private func comment(id: String, content: String? = nil, userId: String = "user") -> CommentItem {
     CommentItem(
       id: id,
       photoId: "photo",
       parentId: nil,
-      userId: "user",
+      userId: userId,
       content: content ?? id,
       status: .approved,
       createdAt: "2026-08-02T00:00:00Z",

--- a/be/apps/core/src/modules/content/comment/comment.controller.ts
+++ b/be/apps/core/src/modules/content/comment/comment.controller.ts
@@ -1,5 +1,10 @@
+import type { HttpContextAuth } from '@core/context/http-context.values'
+import { BizException, ErrorCode } from '@core/errors'
 import { RequireAuth, TenantRoles } from '@core/guards/roles.decorator'
-import { Body, ContextParam, Controller, Delete, Get, Param, Post, Query } from '@tsuki-hono/common'
+import { requireTenantContext } from '@core/modules/platform/tenant/tenant.context'
+import { BlockCommentAuthorDto, ReportCommentDto } from '@core/modules/platform/user-safety/user-safety.dto'
+import { UserSafetyService } from '@core/modules/platform/user-safety/user-safety.service'
+import { Body, ContextParam, Controller, Delete, Get, HttpContext, Param, Post, Query } from '@tsuki-hono/common'
 import type { Context } from 'hono'
 
 import {
@@ -13,7 +18,10 @@ import { CommentService } from './comment.service'
 
 @Controller('comments')
 export class CommentController {
-  constructor(private readonly commentService: CommentService) {}
+  constructor(
+    private readonly commentService: CommentService,
+    private readonly userSafetyService: UserSafetyService,
+  ) {}
 
   @Post('/')
   @RequireAuth()
@@ -43,10 +51,34 @@ export class CommentController {
     return await this.commentService.toggleReaction(commentId, body)
   }
 
+  @Post('/:id/reports')
+  @RequireAuth()
+  async reportComment(@Param('id') commentId: string, @Body() body: ReportCommentDto) {
+    const tenant = requireTenantContext()
+    const userId = this.requireUserId()
+    return await this.userSafetyService.reportComment(tenant.tenant.id, userId, commentId, body)
+  }
+
+  @Post('/:id/block-author')
+  @RequireAuth()
+  async blockCommentAuthor(@Param('id') commentId: string, @Body() body: BlockCommentAuthorDto) {
+    const tenant = requireTenantContext()
+    const userId = this.requireUserId()
+    return await this.userSafetyService.blockCommentAuthor(tenant.tenant.id, userId, commentId, body)
+  }
+
   @Delete('/:id')
   @RequireAuth()
   async deleteComment(@Param('id') commentId: string) {
     await this.commentService.softDelete(commentId)
     return { id: commentId, deleted: true }
+  }
+
+  private requireUserId(): string {
+    const auth = HttpContext.getValue('auth') as HttpContextAuth | undefined
+    if (!auth?.user || !auth.session) {
+      throw new BizException(ErrorCode.AUTH_UNAUTHORIZED)
+    }
+    return auth.user.id
   }
 }

--- a/be/apps/core/src/modules/content/comment/comment.module.ts
+++ b/be/apps/core/src/modules/content/comment/comment.module.ts
@@ -1,4 +1,5 @@
 import { DatabaseModule } from '@core/database/database.module'
+import { UserSafetyModule } from '@core/modules/platform/user-safety/user-safety.module'
 import { Module } from '@tsuki-hono/common'
 
 import { CommentController } from './comment.controller'
@@ -6,7 +7,7 @@ import { AllowAllCommentModerationHook, COMMENT_MODERATION_HOOK } from './commen
 import { CommentService } from './comment.service'
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, UserSafetyModule],
   controllers: [CommentController],
   providers: [
     CommentService,

--- a/be/apps/core/src/modules/content/comment/comment.service.ts
+++ b/be/apps/core/src/modules/content/comment/comment.service.ts
@@ -16,9 +16,10 @@ import { SystemSettingService } from '@core/modules/configuration/system-setting
 import { CommentCreatedEvent } from '@core/modules/content/comment/events/comment-created.event'
 import { WorkspaceMembershipService } from '@core/modules/platform/auth/workspace-membership.service'
 import { requireTenantContext } from '@core/modules/platform/tenant/tenant.context'
+import { UserSafetyService } from '@core/modules/platform/user-safety/user-safety.service'
 import { HttpContext } from '@tsuki-hono/common'
 import { EventEmitterService } from '@tsuki-hono/event-emitter'
-import { and, asc, eq, gt, inArray, isNull, or, sql } from 'drizzle-orm'
+import { and, asc, eq, gt, inArray, isNull, notInArray, or, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
 import { inject, injectable } from 'tsyringe'
 
@@ -53,11 +54,11 @@ interface CommentResponseItem extends CommentViewModel {
   viewerReactions: string[]
 }
 
-type AuthContextValue =
-  | {
-      user?: AuthUser
-      session?: unknown
-    }
+type AuthContextValue
+  = | {
+    user?: AuthUser
+    session?: unknown
+  }
   | undefined
 
 @injectable()
@@ -68,6 +69,7 @@ export class CommentService {
     private readonly eventEmitter: EventEmitterService,
     private readonly systemSettings: SystemSettingService,
     private readonly memberships: WorkspaceMembershipService,
+    private readonly userSafety: UserSafetyService,
   ) {}
 
   async createComment(
@@ -157,7 +159,7 @@ export class CommentService {
     }
 
     // Fetch user info
-    const userIds = [userId, ...Object.values(relations).map((r) => r.userId)].filter(Boolean)
+    const userIds = [userId, ...Object.values(relations).map(r => r.userId)].filter(Boolean)
     const users = await this.fetchUsersWithProfiles(userIds)
 
     // Emit event asynchronously
@@ -191,6 +193,7 @@ export class CommentService {
     const authUser = this.getAuthUser()
     const viewerUserId = authUser?.id ?? null
     const isAdmin = viewerUserId ? await this.memberships.isWorkspaceAdmin(viewerUserId, tenant.tenant.id) : false
+    const blockedUserIds = viewerUserId ? await this.userSafety.blockedUserIds(viewerUserId) : []
     const db = this.dbAccessor.get()
 
     const filters = [
@@ -198,16 +201,21 @@ export class CommentService {
       eq(comments.photoId, query.photoId),
       isNull(comments.deletedAt),
     ]
+    if (blockedUserIds.length > 0) {
+      filters.push(notInArray(comments.userId, blockedUserIds))
+    }
 
     let statusCondition
     if (isAdmin) {
       statusCondition = inArray(comments.status, ['approved', 'pending'])
-    } else if (viewerUserId) {
+    }
+    else if (viewerUserId) {
       statusCondition = or(
         eq(comments.status, 'approved'),
         and(eq(comments.status, 'pending'), eq(comments.userId, viewerUserId)),
       )
-    } else {
+    }
+    else {
       statusCondition = eq(comments.status, 'approved')
     }
     filters.push(statusCondition)
@@ -241,23 +249,22 @@ export class CommentService {
 
     const hasMore = rows.length > query.limit
     const items = rows.slice(0, query.limit)
-    const commentIds = items.map((item) => item.id)
+    const commentIds = items.map(item => item.id)
 
     const reactions = await this.fetchReactionAggregations(tenant.tenant.id, commentIds, viewerUserId)
 
     const nextCursor = hasMore && items.length > 0 ? items.at(-1)!.id : null
 
-    const commentItems = items.map((item) =>
+    const commentItems = items.map(item =>
       this.toResponse({
         ...item,
         reactionCounts: reactions.counts.get(item.id) ?? {},
         viewerReactions: reactions.viewer.get(item.id) ?? [],
-      }),
-    )
+      }))
 
     // Build relations map (parentId -> parent comment)
     const relations: Record<string, CommentResponseItem> = {}
-    const parentIds = [...new Set(items.filter((item) => item.parentId).map((item) => item.parentId!))]
+    const parentIds = [...new Set(items.filter(item => item.parentId).map(item => item.parentId!))]
 
     if (parentIds.length > 0) {
       const parentRows = await db
@@ -273,12 +280,17 @@ export class CommentService {
         })
         .from(comments)
         .where(
-          and(eq(comments.tenantId, tenant.tenant.id), inArray(comments.id, parentIds), isNull(comments.deletedAt)),
+          and(
+            eq(comments.tenantId, tenant.tenant.id),
+            inArray(comments.id, parentIds),
+            isNull(comments.deletedAt),
+            blockedUserIds.length > 0 ? notInArray(comments.userId, blockedUserIds) : undefined,
+          ),
         )
 
       const parentReactions = await this.fetchReactionAggregations(
         tenant.tenant.id,
-        parentRows.map((p) => p.id),
+        parentRows.map(p => p.id),
         viewerUserId,
       )
 
@@ -293,7 +305,7 @@ export class CommentService {
 
     // Build users map (userId -> user)
     const allUserIds = [
-      ...new Set([...items.map((item) => item.userId), ...Object.values(relations).map((r) => r.userId)]),
+      ...new Set([...items.map(item => item.userId), ...Object.values(relations).map(r => r.userId)]),
     ]
 
     const users = await this.fetchUsersWithProfiles(allUserIds)
@@ -358,23 +370,22 @@ export class CommentService {
 
     const hasMore = rows.length > query.limit
     const items = rows.slice(0, query.limit)
-    const commentIds = items.map((item) => item.id)
+    const commentIds = items.map(item => item.id)
 
     const reactions = await this.fetchReactionAggregations(tenant.tenant.id, commentIds, viewerUserId)
 
     const nextCursor = hasMore && items.length > 0 ? items.at(-1)!.id : null
 
-    const commentItems = items.map((item) =>
+    const commentItems = items.map(item =>
       this.toResponse({
         ...item,
         reactionCounts: reactions.counts.get(item.id) ?? {},
         viewerReactions: reactions.viewer.get(item.id) ?? [],
-      }),
-    )
+      }))
 
     // Build relations map (parentId -> parent comment)
     const relations: Record<string, CommentResponseItem> = {}
-    const parentIds = [...new Set(items.filter((item) => item.parentId).map((item) => item.parentId!))]
+    const parentIds = [...new Set(items.filter(item => item.parentId).map(item => item.parentId!))]
 
     if (parentIds.length > 0) {
       const parentRows = await db
@@ -395,7 +406,7 @@ export class CommentService {
 
       const parentReactions = await this.fetchReactionAggregations(
         tenant.tenant.id,
-        parentRows.map((p) => p.id),
+        parentRows.map(p => p.id),
         viewerUserId,
       )
 
@@ -410,7 +421,7 @@ export class CommentService {
 
     // Build users map (userId -> user)
     const allUserIds = [
-      ...new Set([...items.map((item) => item.userId), ...Object.values(relations).map((r) => r.userId)]),
+      ...new Set([...items.map(item => item.userId), ...Object.values(relations).map(r => r.userId)]),
     ]
 
     const users = await this.fetchUsersWithProfiles(allUserIds)
@@ -449,7 +460,8 @@ export class CommentService {
 
     if (existing) {
       await db.delete(commentReactions).where(eq(commentReactions.id, existing.id))
-    } else {
+    }
+    else {
       await db.insert(commentReactions).values({
         tenantId: tenant.tenant.id,
         commentId: comment.id,
@@ -512,6 +524,7 @@ export class CommentService {
     const authUser = this.getAuthUser()
     const viewerUserId = authUser?.id ?? null
     const isAdmin = viewerUserId ? await this.memberships.isWorkspaceAdmin(viewerUserId, tenant.tenant.id) : false
+    const blockedUserIds = viewerUserId ? await this.userSafety.blockedUserIds(viewerUserId) : []
     const db = this.dbAccessor.get()
 
     const filters = [
@@ -519,16 +532,21 @@ export class CommentService {
       eq(comments.photoId, query.photoId),
       isNull(comments.deletedAt),
     ]
+    if (blockedUserIds.length > 0) {
+      filters.push(notInArray(comments.userId, blockedUserIds))
+    }
 
     let statusCondition
     if (isAdmin) {
       statusCondition = inArray(comments.status, ['approved', 'pending'])
-    } else if (viewerUserId) {
+    }
+    else if (viewerUserId) {
       statusCondition = or(
         eq(comments.status, 'approved'),
         and(eq(comments.status, 'pending'), eq(comments.userId, viewerUserId)),
       )
-    } else {
+    }
+    else {
       statusCondition = eq(comments.status, 'approved')
     }
     filters.push(statusCondition)
@@ -697,7 +715,7 @@ export class CommentService {
     return comment
   }
 
-  private toResponse(model: CommentViewModel & { reactionCounts: Record<string, number>; viewerReactions: string[] }) {
+  private toResponse(model: CommentViewModel & { reactionCounts: Record<string, number>, viewerReactions: string[] }) {
     return {
       id: model.id,
       photoId: model.photoId,

--- a/be/apps/core/src/modules/index.module.ts
+++ b/be/apps/core/src/modules/index.module.ts
@@ -40,6 +40,7 @@ import { MobileModule } from './platform/mobile/mobile.module'
 import { PushNotificationModule } from './platform/push-notifications/push-notification.module'
 import { SuperAdminModule } from './platform/super-admin/super-admin.module'
 import { TenantModule } from './platform/tenant/tenant.module'
+import { UserSafetyModule } from './platform/user-safety/user-safety.module'
 
 function createEventModuleOptions(redis: RedisAccessor) {
   return {
@@ -76,6 +77,7 @@ function createEventModuleOptions(redis: RedisAccessor) {
     MobileModule,
     DataManagementModule,
     TenantModule,
+    UserSafetyModule,
     FeaturedGalleriesModule,
     GallerySubscriptionModule,
     PushNotificationModule,

--- a/be/apps/core/src/modules/mail/listeners/content-report-notification.listener.ts
+++ b/be/apps/core/src/modules/mail/listeners/content-report-notification.listener.ts
@@ -1,0 +1,81 @@
+import { authUsers, tenantMemberships, tenants } from '@afilmory/db'
+import { DbAccessor } from '@core/database/database.provider'
+import { SystemSettingService } from '@core/modules/configuration/system-setting/system-setting.service'
+import { ContentReportCreatedEvent } from '@core/modules/platform/user-safety/events/content-report-created.event'
+import { createLogger } from '@tsuki-hono/common'
+import { OnEvent } from '@tsuki-hono/event-emitter'
+import { and, eq, or } from 'drizzle-orm'
+import { injectable } from 'tsyringe'
+
+import { MailService, TEMPLATES } from '../mail.service'
+
+@injectable()
+export class ContentReportNotificationListener {
+  private readonly logger = createLogger('ContentReportNotificationListener')
+
+  constructor(
+    private readonly dbAccessor: DbAccessor,
+    private readonly mailService: MailService,
+    private readonly systemSettings: SystemSettingService,
+  ) {}
+
+  @OnEvent('content.report.created')
+  async handle(event: ContentReportCreatedEvent) {
+    try {
+      await this.sendNotifications(event)
+    }
+    catch (error) {
+      this.logger.error('Failed to notify developers about a content report', error)
+    }
+  }
+
+  private async sendNotifications(event: ContentReportCreatedEvent) {
+    const db = this.dbAccessor.get()
+    const [settings, [tenant], [reporter], [reported], tenantAdmins, platformAdmins] = await Promise.all([
+      this.systemSettings.getSettings(),
+      db.select({ slug: tenants.slug }).from(tenants).where(eq(tenants.id, event.tenantId)).limit(1),
+      db.select({ name: authUsers.name }).from(authUsers).where(eq(authUsers.id, event.reporterUserId)).limit(1),
+      db.select({ name: authUsers.name }).from(authUsers).where(eq(authUsers.id, event.reportedUserId)).limit(1),
+      db
+        .select({ id: authUsers.id, email: authUsers.email })
+        .from(authUsers)
+        .innerJoin(tenantMemberships, eq(tenantMemberships.userId, authUsers.id))
+        .where(
+          and(
+            eq(tenantMemberships.tenantId, event.tenantId),
+            eq(tenantMemberships.status, 'active'),
+            or(eq(tenantMemberships.role, 'owner'), eq(tenantMemberships.role, 'admin')),
+          ),
+        ),
+      db.select({ id: authUsers.id, email: authUsers.email }).from(authUsers).where(eq(authUsers.role, 'superadmin')),
+    ])
+
+    const recipients = new Map<string, string>()
+    for (const user of [...platformAdmins, ...tenantAdmins]) {
+      if (user.id !== event.reportedUserId && user.email) {
+        recipients.set(user.email, user.id)
+      }
+    }
+
+    const host = tenant?.slug ? `${tenant.slug}.${settings.baseDomain}` : settings.baseDomain
+    const photoUrl = `https://${host}/photos/${event.photoId}`
+    for (const email of recipients.keys()) {
+      await this.mailService.sendTemplate(
+        email,
+        'Content report requires review',
+        TEMPLATES.contentReportNotification,
+        {
+          commentId: event.commentId,
+          content: event.contentSnapshot,
+          details: event.details,
+          photoUrl,
+          reason: event.reason,
+          reportedName: reported?.name ?? 'Unknown user',
+          reportedUserId: event.reportedUserId,
+          reporterName: reporter?.name ?? 'Unknown user',
+          reporterUserId: event.reporterUserId,
+        },
+      )
+    }
+  }
+}

--- a/be/apps/core/src/modules/mail/mail.module.ts
+++ b/be/apps/core/src/modules/mail/mail.module.ts
@@ -2,11 +2,12 @@ import { SystemSettingModule } from '@core/modules/configuration/system-setting/
 import { Module } from '@tsuki-hono/common'
 
 import { CommentNotificationListener } from './listeners/comment-notification.listener'
+import { ContentReportNotificationListener } from './listeners/content-report-notification.listener'
 import { MailService } from './mail.service'
 
 @Module({
   imports: [SystemSettingModule],
-  providers: [MailService, CommentNotificationListener],
+  providers: [MailService, CommentNotificationListener, ContentReportNotificationListener],
   exports: [MailService],
 })
 export class MailModule {}

--- a/be/apps/core/src/modules/mail/mail.service.ts
+++ b/be/apps/core/src/modules/mail/mail.service.ts
@@ -6,9 +6,11 @@ import { injectable } from 'tsyringe'
 
 import baseTemplate from './templates/base.ejs?raw'
 import commentNotificationTemplate from './templates/comment-notification.ejs?raw'
+import contentReportNotificationTemplate from './templates/content-report-notification.ejs?raw'
 
 export const TEMPLATES = {
   commentNotification: commentNotificationTemplate,
+  contentReportNotification: contentReportNotificationTemplate,
 }
 
 @injectable()
@@ -19,7 +21,8 @@ export class MailService {
   constructor() {
     if (env.RESEND_API_KEY) {
       this.resend = new Resend(env.RESEND_API_KEY)
-    } else {
+    }
+    else {
       this.logger.warn('RESEND_API_KEY is not set. Mail service will be disabled.')
     }
   }
@@ -40,7 +43,8 @@ export class MailService {
       this.logger.info(`Email sent to ${to}, id: ${data.data?.id}`)
       this.logger.verbose(data)
       return data
-    } catch (error) {
+    }
+    catch (error) {
       this.logger.error(`Failed to send email to ${to}`, error)
       // We don't throw here to prevent blocking the main flow, but we log it.
       // Or should we throw? For notifications, maybe better to just log.

--- a/be/apps/core/src/modules/mail/templates/content-report-notification.ejs
+++ b/be/apps/core/src/modules/mail/templates/content-report-notification.ejs
@@ -1,0 +1,15 @@
+<p>A user submitted a content safety report that requires review.</p>
+<table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
+  <tr><td style="padding: 6px 0; color: #666;">Reason</td><td style="padding: 6px 0;"><strong><%= reason %></strong></td></tr>
+  <tr><td style="padding: 6px 0; color: #666;">Reporter</td><td style="padding: 6px 0;"><%= reporterName %> (<%= reporterUserId %>)</td></tr>
+  <tr><td style="padding: 6px 0; color: #666;">Reported user</td><td style="padding: 6px 0;"><%= reportedName %> (<%= reportedUserId %>)</td></tr>
+  <tr><td style="padding: 6px 0; color: #666;">Comment ID</td><td style="padding: 6px 0;"><%= commentId %></td></tr>
+</table>
+<blockquote style="background: #f5f5f5; padding: 12px; border-left: 4px solid #c62828; margin: 16px 0; white-space: pre-wrap;"><%= content %></blockquote>
+<% if (details) { %>
+  <p><strong>Additional details:</strong> <%= details %></p>
+<% } %>
+<p style="margin-top: 24px;">
+  <a href="<%= photoUrl %>" style="display: inline-block; background: #000; color: #fff; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 500;">Review content</a>
+</p>
+

--- a/be/apps/core/src/modules/platform/featured-galleries/featured-galleries.module.ts
+++ b/be/apps/core/src/modules/platform/featured-galleries/featured-galleries.module.ts
@@ -1,11 +1,12 @@
 import { DatabaseModule } from '@core/database/database.module'
+import { UserSafetyModule } from '@core/modules/platform/user-safety/user-safety.module'
 import { Module } from '@tsuki-hono/common'
 
 import { FeaturedGalleriesController } from './featured-galleries.controller'
 import { FeaturedGalleriesService } from './featured-galleries.service'
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, UserSafetyModule],
   controllers: [FeaturedGalleriesController],
   providers: [FeaturedGalleriesService],
 })

--- a/be/apps/core/src/modules/platform/featured-galleries/featured-galleries.service.ts
+++ b/be/apps/core/src/modules/platform/featured-galleries/featured-galleries.service.ts
@@ -10,6 +10,7 @@ import {
 import { RESERVED_TENANT_SLUGS } from '@afilmory/utils'
 import { DbAccessor } from '@core/database/database.provider'
 import { normalizeDate } from '@core/helpers/normalize.helper'
+import { UserSafetyService } from '@core/modules/platform/user-safety/user-safety.service'
 import { and, asc, eq, ilike, inArray, notInArray, or, sql } from 'drizzle-orm'
 import { injectable } from 'tsyringe'
 
@@ -19,16 +20,21 @@ const DIRECTORY_LIKE_META_PATTERN = /[%_\\]/g
 
 @injectable()
 export class FeaturedGalleriesService {
-  constructor(private readonly dbAccessor: DbAccessor) {}
+  constructor(
+    private readonly dbAccessor: DbAccessor,
+    private readonly userSafety: UserSafetyService,
+  ) {}
 
   async listFeaturedGalleries(userId?: string, options: { query?: string, limit?: number } = {}) {
     const db = this.dbAccessor.get()
     const query = options.query?.trim()
     const limit = Math.min(Math.max(options.limit ?? 20, 1), 40)
+    const blockedTenantIds = userId ? await this.userSafety.blockedOwnerTenantIds(userId) : []
     const visibilityConditions = [
       eq(tenants.banned, false),
       eq(tenants.status, 'active'),
       notInArray(tenants.slug, RESERVED_TENANT_SLUGS),
+      blockedTenantIds.length > 0 ? notInArray(tenants.id, blockedTenantIds) : undefined,
     ]
     const escapedQuery = query?.replaceAll(DIRECTORY_LIKE_META_PATTERN, '\\$&')
     const searchPattern = escapedQuery ? `%${escapedQuery}%` : undefined

--- a/be/apps/core/src/modules/platform/gallery-subscriptions/gallery-subscription.module.ts
+++ b/be/apps/core/src/modules/platform/gallery-subscriptions/gallery-subscription.module.ts
@@ -1,11 +1,12 @@
 import { DatabaseModule } from '@core/database/database.module'
+import { UserSafetyModule } from '@core/modules/platform/user-safety/user-safety.module'
 import { Module } from '@tsuki-hono/common'
 
 import { GallerySubscriptionController } from './gallery-subscription.controller'
 import { GallerySubscriptionService } from './gallery-subscription.service'
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, UserSafetyModule],
   controllers: [GallerySubscriptionController],
   providers: [GallerySubscriptionService],
 })

--- a/be/apps/core/src/modules/platform/gallery-subscriptions/gallery-subscription.service.ts
+++ b/be/apps/core/src/modules/platform/gallery-subscriptions/gallery-subscription.service.ts
@@ -10,7 +10,8 @@ import {
 import { DbAccessor } from '@core/database/database.provider'
 import { BizException, ErrorCode } from '@core/errors'
 import { normalizeDate } from '@core/helpers/normalize.helper'
-import { and, asc, eq, gte, inArray, sql } from 'drizzle-orm'
+import { UserSafetyService } from '@core/modules/platform/user-safety/user-safety.service'
+import { and, asc, eq, gte, inArray, notInArray, sql } from 'drizzle-orm'
 import { injectable } from 'tsyringe'
 
 import { evaluateGallerySubscription } from './gallery-subscription.policy'
@@ -30,7 +31,10 @@ export type GallerySubscriptionRecord = {
 
 @injectable()
 export class GallerySubscriptionService {
-  constructor(private readonly dbAccessor: DbAccessor) {}
+  constructor(
+    private readonly dbAccessor: DbAccessor,
+    private readonly userSafety: UserSafetyService,
+  ) {}
 
   async listForUser(userId: string): Promise<GallerySubscriptionSummary[]> {
     const context = await this.loadEligibleTargets(userId)
@@ -94,13 +98,19 @@ export class GallerySubscriptionService {
     targets: Record<string, SubscriptionTarget>
   }> {
     const db = this.dbAccessor.get()
+    const blockedTenantIds = await this.userSafety.blockedOwnerTenantIds(userId)
     const subscriptions = await db
       .select({
         tenantId: gallerySubscriptions.targetTenantId,
         createdAt: gallerySubscriptions.createdAt,
       })
       .from(gallerySubscriptions)
-      .where(eq(gallerySubscriptions.subscriberUserId, userId))
+      .where(
+        and(
+          eq(gallerySubscriptions.subscriberUserId, userId),
+          blockedTenantIds.length > 0 ? notInArray(gallerySubscriptions.targetTenantId, blockedTenantIds) : undefined,
+        ),
+      )
 
     if (subscriptions.length === 0) {
       return { memberTenantIds: new Set(), subscriptions: [], targets: {} }
@@ -247,6 +257,10 @@ export class GallerySubscriptionService {
 
   async subscribe(userId: string, targetTenantId: string): Promise<GallerySubscriptionRecord> {
     const db = this.dbAccessor.get()
+    const blockedTenantIds = await this.userSafety.blockedOwnerTenantIds(userId)
+    if (blockedTenantIds.includes(targetTenantId)) {
+      throw new BizException(ErrorCode.COMMON_NOT_FOUND, { message: 'Gallery not found.' })
+    }
     const [[target], [activeMembership]] = await Promise.all([
       db
         .select({

--- a/be/apps/core/src/modules/platform/user-safety/events/content-report-created.event.ts
+++ b/be/apps/core/src/modules/platform/user-safety/events/content-report-created.event.ts
@@ -1,0 +1,16 @@
+import type { CommentReportReason } from '../user-safety.types'
+
+export class ContentReportCreatedEvent {
+  constructor(
+    public readonly reportId: string,
+    public readonly tenantId: string,
+    public readonly photoId: string,
+    public readonly commentId: string,
+    public readonly reporterUserId: string,
+    public readonly reportedUserId: string,
+    public readonly reason: CommentReportReason,
+    public readonly details: string | null,
+    public readonly contentSnapshot: string,
+    public readonly createdAt: string,
+  ) {}
+}

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.controller.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.controller.ts
@@ -1,0 +1,38 @@
+import type { HttpContextAuth } from '@core/context/http-context.values'
+import { AllowPlaceholderTenant } from '@core/decorators/allow-placeholder.decorator'
+import { SkipTenantGuard } from '@core/decorators/skip-tenant.decorator'
+import { BizException, ErrorCode } from '@core/errors'
+import { RequireAuth } from '@core/guards/roles.decorator'
+import { BypassResponseTransform } from '@core/interceptors/response-transform.decorator'
+import { Controller, Delete, Get, HttpContext, Param } from '@tsuki-hono/common'
+
+import { BlockedUserParamDto } from './user-safety.dto'
+import { UserSafetyService } from './user-safety.service'
+
+@Controller('user-blocks')
+@SkipTenantGuard()
+@AllowPlaceholderTenant()
+@RequireAuth()
+@BypassResponseTransform()
+export class UserSafetyController {
+  constructor(private readonly safety: UserSafetyService) {}
+
+  @Get('/')
+  async list() {
+    return { users: await this.safety.listBlockedUsers(this.requireUserId()) }
+  }
+
+  @Delete('/:userId')
+  async unblock(@Param() { userId }: BlockedUserParamDto) {
+    await this.safety.unblockUser(this.requireUserId(), userId)
+    return { blocked: false, userId }
+  }
+
+  private requireUserId(): string {
+    const auth = HttpContext.getValue('auth') as HttpContextAuth | undefined
+    if (!auth?.user || !auth.session) {
+      throw new BizException(ErrorCode.AUTH_UNAUTHORIZED)
+    }
+    return auth.user.id
+  }
+}

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.dto.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.dto.ts
@@ -1,0 +1,26 @@
+import { createZodSchemaDto } from '@tsuki-hono/common'
+import { z } from 'zod'
+
+import { COMMENT_REPORT_REASONS } from './user-safety.types'
+
+const CommentReportReasonSchema = z.enum(COMMENT_REPORT_REASONS)
+
+export const ReportCommentSchema = z.object({
+  reason: CommentReportReasonSchema,
+  details: z.string().trim().max(500).optional(),
+})
+
+export class ReportCommentDto extends createZodSchemaDto(ReportCommentSchema) {}
+
+export const BlockCommentAuthorSchema = z.object({
+  reason: CommentReportReasonSchema.default('abusive_behavior'),
+  details: z.string().trim().max(500).optional(),
+})
+
+export class BlockCommentAuthorDto extends createZodSchemaDto(BlockCommentAuthorSchema) {}
+
+export const BlockedUserParamSchema = z.object({
+  userId: z.string().trim().min(1),
+})
+
+export class BlockedUserParamDto extends createZodSchemaDto(BlockedUserParamSchema) {}

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.module.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.module.ts
@@ -1,0 +1,12 @@
+import { DatabaseModule } from '@core/database/database.module'
+import { Module } from '@tsuki-hono/common'
+
+import { UserSafetyController } from './user-safety.controller'
+import { UserSafetyService } from './user-safety.service'
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [UserSafetyController],
+  providers: [UserSafetyService],
+})
+export class UserSafetyModule {}

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.policy.spec.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.policy.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { canTargetUser, excludeBlockedAuthors } from './user-safety.policy'
+
+describe('user safety policy', () => {
+  it('prevents reporting or blocking the acting user', () => {
+    expect(canTargetUser('viewer', 'viewer')).toBe(false)
+    expect(canTargetUser('viewer', 'author')).toBe(true)
+  })
+
+  it('removes every record authored by a blocked user while retaining unrelated content', () => {
+    const visible = excludeBlockedAuthors(
+      [
+        { id: 'one', userId: 'blocked' },
+        { id: 'two', userId: 'visible' },
+        { id: 'three', userId: 'blocked' },
+      ],
+      new Set(['blocked']),
+      record => record.userId,
+    )
+
+    expect(visible.map(record => record.id)).toEqual(['two'])
+  })
+})

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.policy.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.policy.ts
@@ -1,0 +1,17 @@
+export function canTargetUser(actorUserId: string, targetUserId: string): boolean {
+  return actorUserId.length > 0 && targetUserId.length > 0 && actorUserId !== targetUserId
+}
+
+export function excludeBlockedAuthors<T>(
+  records: T[],
+  blockedUserIds: ReadonlySet<string>,
+  author: (record: T) => string | null | undefined,
+): T[] {
+  if (blockedUserIds.size === 0) {
+    return records
+  }
+  return records.filter((record) => {
+    const authorId = author(record)
+    return !authorId || !blockedUserIds.has(authorId)
+  })
+}

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.service.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.service.ts
@@ -1,0 +1,253 @@
+import { authUsers, comments, contentReports, gallerySubscriptions, tenantMemberships, userBlocks } from '@afilmory/db'
+import { DbAccessor } from '@core/database/database.provider'
+import { BizException, ErrorCode } from '@core/errors'
+import { logger } from '@core/helpers/logger.helper'
+import { EventEmitterService } from '@tsuki-hono/event-emitter'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { injectable } from 'tsyringe'
+
+import { ContentReportCreatedEvent } from './events/content-report-created.event'
+import { canTargetUser } from './user-safety.policy'
+import type { CommentReportReason } from './user-safety.types'
+
+interface ReportInput {
+  details?: string
+  reason: CommentReportReason
+}
+
+interface CommentSafetyTarget {
+  content: string
+  createdAt: string
+  id: string
+  photoId: string
+  userId: string
+}
+
+@injectable()
+export class UserSafetyService {
+  constructor(
+    private readonly dbAccessor: DbAccessor,
+    private readonly eventEmitter: EventEmitterService,
+  ) {}
+
+  async reportComment(tenantId: string, reporterUserId: string, commentId: string, input: ReportInput) {
+    const db = this.dbAccessor.get()
+    const comment = await this.findComment(tenantId, commentId)
+    this.ensureCanTarget(reporterUserId, comment.userId)
+
+    const [created] = await db
+      .insert(contentReports)
+      .values({
+        tenantId,
+        commentId: comment.id,
+        reporterUserId,
+        reportedUserId: comment.userId,
+        reason: input.reason,
+        details: input.details || null,
+        contentSnapshot: comment.content,
+      })
+      .onConflictDoNothing()
+      .returning({
+        id: contentReports.id,
+        createdAt: contentReports.createdAt,
+      })
+
+    const report = created ?? (await this.findExistingReport(reporterUserId, comment.id))
+    if (!report) {
+      throw new BizException(ErrorCode.COMMON_CONFLICT, { message: 'The report could not be recorded.' })
+    }
+
+    if (created) {
+      this.emitReportCreated(tenantId, reporterUserId, comment, input, created)
+    }
+
+    return {
+      reportId: report.id,
+      reported: true,
+      status: 'pending' as const,
+    }
+  }
+
+  async blockCommentAuthor(tenantId: string, blockerUserId: string, commentId: string, input: ReportInput) {
+    const db = this.dbAccessor.get()
+    const comment = await this.findComment(tenantId, commentId)
+    this.ensureCanTarget(blockerUserId, comment.userId)
+
+    const result = await db.transaction(async (tx) => {
+      const [createdReport] = await tx
+        .insert(contentReports)
+        .values({
+          tenantId,
+          commentId: comment.id,
+          reporterUserId: blockerUserId,
+          reportedUserId: comment.userId,
+          reason: input.reason,
+          details: input.details || null,
+          contentSnapshot: comment.content,
+        })
+        .onConflictDoNothing()
+        .returning({
+          id: contentReports.id,
+          createdAt: contentReports.createdAt,
+        })
+
+      await tx
+        .insert(userBlocks)
+        .values({
+          blockerUserId,
+          blockedUserId: comment.userId,
+        })
+        .onConflictDoNothing()
+
+      const ownedTenants = await tx
+        .select({ tenantId: tenantMemberships.tenantId })
+        .from(tenantMemberships)
+        .where(
+          and(
+            eq(tenantMemberships.userId, comment.userId),
+            eq(tenantMemberships.role, 'owner'),
+            eq(tenantMemberships.status, 'active'),
+          ),
+        )
+
+      const tenantIds = ownedTenants.map(item => item.tenantId)
+      if (tenantIds.length > 0) {
+        await tx
+          .delete(gallerySubscriptions)
+          .where(
+            and(
+              eq(gallerySubscriptions.subscriberUserId, blockerUserId),
+              inArray(gallerySubscriptions.targetTenantId, tenantIds),
+            ),
+          )
+      }
+
+      return { createdReport }
+    })
+
+    if (result.createdReport) {
+      this.emitReportCreated(tenantId, blockerUserId, comment, input, result.createdReport)
+    }
+
+    return {
+      blocked: true,
+      blockedUserId: comment.userId,
+      reported: true,
+    }
+  }
+
+  async blockedUserIds(blockerUserId: string): Promise<string[]> {
+    const db = this.dbAccessor.get()
+    const rows = await db
+      .select({ userId: userBlocks.blockedUserId })
+      .from(userBlocks)
+      .where(eq(userBlocks.blockerUserId, blockerUserId))
+    return rows.map(row => row.userId)
+  }
+
+  async blockedOwnerTenantIds(blockerUserId: string): Promise<string[]> {
+    const db = this.dbAccessor.get()
+    const rows = await db
+      .select({ tenantId: tenantMemberships.tenantId })
+      .from(userBlocks)
+      .innerJoin(
+        tenantMemberships,
+        and(
+          eq(tenantMemberships.userId, userBlocks.blockedUserId),
+          eq(tenantMemberships.role, 'owner'),
+          eq(tenantMemberships.status, 'active'),
+        ),
+      )
+      .where(eq(userBlocks.blockerUserId, blockerUserId))
+    return [...new Set(rows.map(row => row.tenantId))]
+  }
+
+  async listBlockedUsers(blockerUserId: string) {
+    const db = this.dbAccessor.get()
+    return await db
+      .select({
+        id: authUsers.id,
+        name: authUsers.name,
+        image: authUsers.image,
+        blockedAt: userBlocks.createdAt,
+      })
+      .from(userBlocks)
+      .innerJoin(authUsers, eq(authUsers.id, userBlocks.blockedUserId))
+      .where(eq(userBlocks.blockerUserId, blockerUserId))
+  }
+
+  async unblockUser(blockerUserId: string, blockedUserId: string): Promise<boolean> {
+    const db = this.dbAccessor.get()
+    const deleted = await db
+      .delete(userBlocks)
+      .where(and(eq(userBlocks.blockerUserId, blockerUserId), eq(userBlocks.blockedUserId, blockedUserId)))
+      .returning({ id: userBlocks.id })
+    return deleted.length > 0
+  }
+
+  private ensureCanTarget(actorUserId: string, targetUserId: string) {
+    if (!canTargetUser(actorUserId, targetUserId)) {
+      throw new BizException(ErrorCode.COMMON_BAD_REQUEST, { message: 'You cannot report or block yourself.' })
+    }
+  }
+
+  private async findComment(tenantId: string, commentId: string): Promise<CommentSafetyTarget> {
+    const db = this.dbAccessor.get()
+    const [comment] = await db
+      .select({
+        id: comments.id,
+        photoId: comments.photoId,
+        userId: comments.userId,
+        content: comments.content,
+        createdAt: comments.createdAt,
+      })
+      .from(comments)
+      .where(and(eq(comments.id, commentId), eq(comments.tenantId, tenantId), isNull(comments.deletedAt)))
+      .limit(1)
+    if (!comment) {
+      throw new BizException(ErrorCode.COMMON_NOT_FOUND, { message: 'Comment not found.' })
+    }
+    return comment
+  }
+
+  private async findExistingReport(reporterUserId: string, commentId: string) {
+    const db = this.dbAccessor.get()
+    const [report] = await db
+      .select({
+        id: contentReports.id,
+        createdAt: contentReports.createdAt,
+      })
+      .from(contentReports)
+      .where(and(eq(contentReports.reporterUserId, reporterUserId), eq(contentReports.commentId, commentId)))
+      .limit(1)
+    return report
+  }
+
+  private emitReportCreated(
+    tenantId: string,
+    reporterUserId: string,
+    comment: CommentSafetyTarget,
+    input: ReportInput,
+    report: { createdAt: string, id: string },
+  ) {
+    this.eventEmitter
+      .emit(
+        'content.report.created',
+        new ContentReportCreatedEvent(
+          report.id,
+          tenantId,
+          comment.photoId,
+          comment.id,
+          reporterUserId,
+          comment.userId,
+          input.reason,
+          input.details || null,
+          comment.content,
+          report.createdAt,
+        ),
+      )
+      .catch((error) => {
+        logger.error('Failed to emit content.report.created event', error)
+      })
+  }
+}

--- a/be/apps/core/src/modules/platform/user-safety/user-safety.types.ts
+++ b/be/apps/core/src/modules/platform/user-safety/user-safety.types.ts
@@ -1,0 +1,10 @@
+export const COMMENT_REPORT_REASONS = [
+  'spam',
+  'harassment',
+  'hate_or_violence',
+  'sexual_content',
+  'abusive_behavior',
+  'other',
+] as const
+
+export type CommentReportReason = (typeof COMMENT_REPORT_REASONS)[number]

--- a/be/packages/db/migrations/0026_overjoyed_marauders.sql
+++ b/be/packages/db/migrations/0026_overjoyed_marauders.sql
@@ -1,0 +1,34 @@
+CREATE TYPE "public"."content_report_status" AS ENUM('pending', 'reviewed', 'dismissed', 'actioned');--> statement-breakpoint
+CREATE TABLE "content_report" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"comment_id" text,
+	"reporter_user_id" text NOT NULL,
+	"reported_user_id" text NOT NULL,
+	"reason" text NOT NULL,
+	"details" text,
+	"content_snapshot" text NOT NULL,
+	"status" "content_report_status" DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_content_report_reporter_comment" UNIQUE("reporter_user_id","comment_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_block" (
+	"id" text PRIMARY KEY NOT NULL,
+	"blocker_user_id" text NOT NULL,
+	"blocked_user_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_user_block_pair" UNIQUE("blocker_user_id","blocked_user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "content_report" ADD CONSTRAINT "content_report_tenant_id_tenant_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenant"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "content_report" ADD CONSTRAINT "content_report_comment_id_comment_id_fk" FOREIGN KEY ("comment_id") REFERENCES "public"."comment"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "content_report" ADD CONSTRAINT "content_report_reporter_user_id_auth_user_id_fk" FOREIGN KEY ("reporter_user_id") REFERENCES "public"."auth_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "content_report" ADD CONSTRAINT "content_report_reported_user_id_auth_user_id_fk" FOREIGN KEY ("reported_user_id") REFERENCES "public"."auth_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_block" ADD CONSTRAINT "user_block_blocker_user_id_auth_user_id_fk" FOREIGN KEY ("blocker_user_id") REFERENCES "public"."auth_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_block" ADD CONSTRAINT "user_block_blocked_user_id_auth_user_id_fk" FOREIGN KEY ("blocked_user_id") REFERENCES "public"."auth_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_content_report_tenant_status" ON "content_report" USING btree ("tenant_id","status","created_at");--> statement-breakpoint
+CREATE INDEX "idx_content_report_reported_user" ON "content_report" USING btree ("reported_user_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_user_block_blocker" ON "user_block" USING btree ("blocker_user_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_user_block_blocked" ON "user_block" USING btree ("blocked_user_id","created_at");

--- a/be/packages/db/migrations/meta/0026_snapshot.json
+++ b/be/packages/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,4375 @@
+{
+  "id": "16737bf6-1a4d-4a06-b215-c8a447523485",
+  "prevId": "a5784a8a-3edf-49ea-aea7-4e572239de96",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_deletion_request": {
+      "name": "account_deletion_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_token_hash": {
+          "name": "status_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "account_deletion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "stage": {
+          "name": "stage",
+          "type": "account_deletion_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'revoke_providers'"
+        },
+        "impact_snapshot": {
+          "name": "impact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_revoked_at": {
+          "name": "access_revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_account_deletion_active_user": {
+          "name": "uq_account_deletion_active_user",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"account_deletion_request\".\"subject_user_id\" is not null and \"account_deletion_request\".\"status\" <> 'completed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_deletion_retry": {
+          "name": "idx_account_deletion_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_account_deletion_status_token_hash": {
+          "name": "uq_account_deletion_status_token_hash",
+          "nullsNotDistinct": false,
+          "columns": ["status_token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apns_device": {
+      "name": "apns_device",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_token": {
+          "name": "device_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "apns_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_apns_device_user_enabled": {
+          "name": "idx_apns_device_user_enabled",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apns_device_user_id_auth_user_id_fk": {
+          "name": "apns_device_user_id_auth_user_id_fk",
+          "tableFrom": "apns_device",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_apns_device_token_environment": {
+          "name": "uq_apns_device_token_environment",
+          "nullsNotDistinct": false,
+          "columns": ["device_token", "environment"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apple_authorization": {
+      "name": "apple_authorization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code_hash": {
+          "name": "authorization_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "apple_authorization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_revocation_error": {
+          "name": "last_revocation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_apple_authorization_code_hash": {
+          "name": "uq_apple_authorization_code_hash",
+          "columns": [
+            {
+              "expression": "authorization_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_apple_authorization_user_status": {
+          "name": "idx_apple_authorization_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apple_authorization_user_id_auth_user_id_fk": {
+          "name": "apple_authorization_user_id_auth_user_id_fk",
+          "tableFrom": "apple_authorization",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apple_authorization_account_id_auth_account_id_fk": {
+          "name": "apple_authorization_account_id_auth_account_id_fk",
+          "tableFrom": "apple_authorization",
+          "tableTo": "auth_account",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_apple_authorization_account": {
+          "name": "uq_apple_authorization_account",
+          "nullsNotDistinct": false,
+          "columns": ["account_id"]
+        },
+        "uq_apple_authorization_subject_client": {
+          "name": "uq_apple_authorization_subject_client",
+          "nullsNotDistinct": false,
+          "columns": ["subject", "client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_account_user": {
+          "name": "idx_auth_account_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_auth_account_provider": {
+          "name": "uq_auth_account_provider",
+          "nullsNotDistinct": false,
+          "columns": ["provider_id", "account_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tenant_id": {
+          "name": "active_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_session_active_tenant_id_tenant_id_fk": {
+          "name": "auth_session_active_tenant_id_tenant_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "tenant",
+          "columnsFrom": ["active_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creem_customer_id": {
+          "name": "creem_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "had_trial": {
+          "name": "had_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "platform_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_requested_at": {
+          "name": "deletion_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_signed_in_at": {
+          "name": "last_signed_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_surface": {
+          "name": "last_active_surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_auth_user_email_normalized": {
+          "name": "uq_auth_user_email_normalized",
+          "columns": [
+            {
+              "expression": "lower(trim(\"email\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_entitlement": {
+      "name": "billing_entitlement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "billing_entitlement_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "billing_entitlement_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_entitlement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_entitlement_tenant_status": {
+          "name": "idx_billing_entitlement_tenant_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_entitlement_tenant_id_tenant_id_fk": {
+          "name": "billing_entitlement_tenant_id_tenant_id_fk",
+          "tableFrom": "billing_entitlement",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_billing_entitlement_source_kind": {
+          "name": "uq_billing_entitlement_source_kind",
+          "nullsNotDistinct": false,
+          "columns": ["source_type", "source_id", "kind"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_offer_product": {
+      "name": "billing_offer_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "billing_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_product_id": {
+          "name": "external_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_offer_product_offer": {
+          "name": "idx_billing_offer_product_offer",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_offer_product_offer_id_billing_offer_id_fk": {
+          "name": "billing_offer_product_offer_id_billing_offer_id_fk",
+          "tableFrom": "billing_offer_product",
+          "tableTo": "billing_offer",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_billing_offer_product_provider_environment_external": {
+          "name": "uq_billing_offer_product_provider_environment_external",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "environment", "external_product_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_offer": {
+      "name": "billing_offer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_plan_id": {
+          "name": "application_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_plan_id": {
+          "name": "storage_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_provider_event": {
+      "name": "billing_provider_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "billing_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_subscription_id": {
+          "name": "external_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "billing_provider_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_provider_event_processing": {
+          "name": "idx_billing_provider_event_processing",
+          "columns": [
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_billing_provider_event_provider_environment_external": {
+          "name": "uq_billing_provider_event_provider_environment_external",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "environment", "external_event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_subject": {
+      "name": "billing_subject",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_account_token": {
+          "name": "app_account_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_owner_user_id": {
+          "name": "billing_owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tombstoned_at": {
+          "name": "tombstoned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_subject_tenant_id_tenant_id_fk": {
+          "name": "billing_subject_tenant_id_tenant_id_fk",
+          "tableFrom": "billing_subject",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_subject_billing_owner_user_id_auth_user_id_fk": {
+          "name": "billing_subject_billing_owner_user_id_auth_user_id_fk",
+          "tableFrom": "billing_subject",
+          "tableTo": "auth_user",
+          "columnsFrom": ["billing_owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_billing_subject_app_account_token": {
+          "name": "uq_billing_subject_app_account_token",
+          "nullsNotDistinct": false,
+          "columns": ["app_account_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_subscription": {
+      "name": "billing_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_owner_user_id": {
+          "name": "billing_owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "billing_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_subscription_id": {
+          "name": "external_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_transaction_id": {
+          "name": "original_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_account_token": {
+          "name": "app_account_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_billing_subscription_provider_environment_original": {
+          "name": "uq_billing_subscription_provider_environment_original",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "original_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_subscription\".\"original_transaction_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_subscription_tenant_status": {
+          "name": "idx_billing_subscription_tenant_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_subscription_app_account_token": {
+          "name": "idx_billing_subscription_app_account_token",
+          "columns": [
+            {
+              "expression": "app_account_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscription_tenant_id_tenant_id_fk": {
+          "name": "billing_subscription_tenant_id_tenant_id_fk",
+          "tableFrom": "billing_subscription",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_subscription_billing_owner_user_id_auth_user_id_fk": {
+          "name": "billing_subscription_billing_owner_user_id_auth_user_id_fk",
+          "tableFrom": "billing_subscription",
+          "tableTo": "auth_user",
+          "columnsFrom": ["billing_owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "billing_subscription_offer_id_billing_offer_id_fk": {
+          "name": "billing_subscription_offer_id_billing_offer_id_fk",
+          "tableFrom": "billing_subscription",
+          "tableTo": "billing_offer",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_billing_subscription_provider_environment_external": {
+          "name": "uq_billing_subscription_provider_environment_external",
+          "nullsNotDistinct": false,
+          "columns": ["provider", "environment", "external_subscription_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_usage_event": {
+      "name": "billing_usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'count'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_usage_event_tenant": {
+          "name": "idx_billing_usage_event_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_usage_event_type": {
+          "name": "idx_billing_usage_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_usage_event_tenant_id_tenant_id_fk": {
+          "name": "billing_usage_event_tenant_id_tenant_id_fk",
+          "tableFrom": "billing_usage_event",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reaction": {
+      "name": "comment_reaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comment_reaction_comment": {
+          "name": "idx_comment_reaction_comment",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reaction_tenant_id_tenant_id_fk": {
+          "name": "comment_reaction_tenant_id_tenant_id_fk",
+          "tableFrom": "comment_reaction",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reaction_comment_id_comment_id_fk": {
+          "name": "comment_reaction_comment_id_comment_id_fk",
+          "tableFrom": "comment_reaction",
+          "tableTo": "comment",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reaction_user_id_auth_user_id_fk": {
+          "name": "comment_reaction_user_id_auth_user_id_fk",
+          "tableFrom": "comment_reaction",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_comment_reaction_user": {
+          "name": "uq_comment_reaction_user",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "comment_id", "user_id", "reaction"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "comment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_comment_tenant_photo": {
+          "name": "idx_comment_tenant_photo",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "photo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_parent": {
+          "name": "idx_comment_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_user": {
+          "name": "idx_comment_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_tenant_id_tenant_id_fk": {
+          "name": "comment_tenant_id_tenant_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_user_id_auth_user_id_fk": {
+          "name": "comment_user_id_auth_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_comment_parent": {
+          "name": "fk_comment_parent",
+          "tableFrom": "comment",
+          "tableTo": "comment",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_report": {
+      "name": "content_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_user_id": {
+          "name": "reporter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_user_id": {
+          "name": "reported_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "content_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_content_report_tenant_status": {
+          "name": "idx_content_report_tenant_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_content_report_reported_user": {
+          "name": "idx_content_report_reported_user",
+          "columns": [
+            {
+              "expression": "reported_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_report_tenant_id_tenant_id_fk": {
+          "name": "content_report_tenant_id_tenant_id_fk",
+          "tableFrom": "content_report",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_report_comment_id_comment_id_fk": {
+          "name": "content_report_comment_id_comment_id_fk",
+          "tableFrom": "content_report",
+          "tableTo": "comment",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "content_report_reporter_user_id_auth_user_id_fk": {
+          "name": "content_report_reporter_user_id_auth_user_id_fk",
+          "tableFrom": "content_report",
+          "tableTo": "auth_user",
+          "columnsFrom": ["reporter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_report_reported_user_id_auth_user_id_fk": {
+          "name": "content_report_reported_user_id_auth_user_id_fk",
+          "tableFrom": "content_report",
+          "tableTo": "auth_user",
+          "columnsFrom": ["reported_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_content_report_reporter_comment": {
+          "name": "uq_content_report_reporter_comment",
+          "nullsNotDistinct": false,
+          "columns": ["reporter_user_id", "comment_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creem_subscription": {
+      "name": "creem_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creem_customer_id": {
+          "name": "creem_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creem_subscription_id": {
+          "name": "creem_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creem_order_id": {
+          "name": "creem_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creem_subscription_tenant_id_tenant_id_fk": {
+          "name": "creem_subscription_tenant_id_tenant_id_fk",
+          "tableFrom": "creem_subscription",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gallery_subscription": {
+      "name": "gallery_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_user_id": {
+          "name": "subscriber_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_tenant_id": {
+          "name": "target_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gallery_subscription_target": {
+          "name": "idx_gallery_subscription_target",
+          "columns": [
+            {
+              "expression": "target_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gallery_subscription_subscriber_created": {
+          "name": "idx_gallery_subscription_subscriber_created",
+          "columns": [
+            {
+              "expression": "subscriber_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gallery_subscription_subscriber_user_id_auth_user_id_fk": {
+          "name": "gallery_subscription_subscriber_user_id_auth_user_id_fk",
+          "tableFrom": "gallery_subscription",
+          "tableTo": "auth_user",
+          "columnsFrom": ["subscriber_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gallery_subscription_target_tenant_id_tenant_id_fk": {
+          "name": "gallery_subscription_target_tenant_id_tenant_id_fk",
+          "tableFrom": "gallery_subscription",
+          "tableTo": "tenant",
+          "columnsFrom": ["target_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_gallery_subscription_subscriber_target": {
+          "name": "uq_gallery_subscription_subscriber_target",
+          "nullsNotDistinct": false,
+          "columns": ["subscriber_user_id", "target_tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_storage_file_reference": {
+      "name": "managed_storage_file_reference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_managed_storage_file_ref_provider": {
+          "name": "idx_managed_storage_file_ref_provider",
+          "columns": [
+            {
+              "expression": "provider_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_managed_storage_file_ref_reference": {
+          "name": "idx_managed_storage_file_ref_reference",
+          "columns": [
+            {
+              "expression": "reference_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_storage_file_reference_tenant_id_tenant_id_fk": {
+          "name": "managed_storage_file_reference_tenant_id_tenant_id_fk",
+          "tableFrom": "managed_storage_file_reference",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_managed_storage_file_ref_tenant_key": {
+          "name": "uq_managed_storage_file_ref_tenant_key",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "storage_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_storage_usage": {
+      "name": "managed_storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key": {
+          "name": "provider_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bytes": {
+          "name": "total_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_managed_storage_usage_tenant_recorded": {
+          "name": "idx_managed_storage_usage_tenant_recorded",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_managed_storage_usage_provider": {
+          "name": "idx_managed_storage_usage_provider",
+          "columns": [
+            {
+              "expression": "provider_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_storage_usage_tenant_id_tenant_id_fk": {
+          "name": "managed_storage_usage_tenant_id_tenant_id_fk",
+          "tableFrom": "managed_storage_usage",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_storage_handoff": {
+      "name": "mobile_storage_handoff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_token_hash": {
+          "name": "capability_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mobile_storage_handoff_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'issued'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_expires_at": {
+          "name": "capability_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_mobile_storage_handoff_capability_token_hash": {
+          "name": "uq_mobile_storage_handoff_capability_token_hash",
+          "columns": [
+            {
+              "expression": "capability_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mobile_storage_handoff\".\"capability_token_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mobile_storage_handoff_tenant_status": {
+          "name": "idx_mobile_storage_handoff_tenant_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_storage_handoff_tenant_id_tenant_id_fk": {
+          "name": "mobile_storage_handoff_tenant_id_tenant_id_fk",
+          "tableFrom": "mobile_storage_handoff",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mobile_storage_handoff_user_id_auth_user_id_fk": {
+          "name": "mobile_storage_handoff_user_id_auth_user_id_fk",
+          "tableFrom": "mobile_storage_handoff",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_mobile_storage_handoff_token_hash": {
+          "name": "uq_mobile_storage_handoff_token_hash",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.photo_asset": {
+      "name": "photo_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v10'"
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "photo_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "conflict_reason": {
+          "name": "conflict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_payload": {
+          "name": "conflict_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_photo_asset_tenant_synced": {
+          "name": "idx_photo_asset_tenant_synced",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "photo_asset_tenant_id_tenant_id_fk": {
+          "name": "photo_asset_tenant_id_tenant_id_fk",
+          "tableFrom": "photo_asset",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_photo_asset_tenant_storage_key": {
+          "name": "uq_photo_asset_tenant_storage_key",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "storage_key"]
+        },
+        "uq_photo_asset_tenant_photo_id": {
+          "name": "uq_photo_asset_tenant_photo_id",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "photo_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.photo_sync_run": {
+      "name": "photo_sync_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actions_count": {
+          "name": "actions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_photo_sync_run_tenant": {
+          "name": "idx_photo_sync_run_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "photo_sync_run_tenant_id_tenant_id_fk": {
+          "name": "photo_sync_run_tenant_id_tenant_id_fk",
+          "tableFrom": "photo_sync_run",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_activity_event": {
+      "name": "platform_activity_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_activity_user_occurred": {
+          "name": "idx_platform_activity_user_occurred",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_activity_tenant_occurred": {
+          "name": "idx_platform_activity_tenant_occurred",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_activity_type_occurred": {
+          "name": "idx_platform_activity_type_occurred",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_activity_event_user_id_auth_user_id_fk": {
+          "name": "platform_activity_event_user_id_auth_user_id_fk",
+          "tableFrom": "platform_activity_event",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "platform_activity_event_tenant_id_tenant_id_fk": {
+          "name": "platform_activity_event_tenant_id_tenant_id_fk",
+          "tableFrom": "platform_activity_event",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_key": {
+          "name": "ref_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_reactions_tenant_ref_key": {
+          "name": "idx_reactions_tenant_ref_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_tenant_id_tenant_id_fk": {
+          "name": "reactions_tenant_id_tenant_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_tenant_id_tenant_id_fk": {
+          "name": "settings_tenant_id_tenant_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_settings_tenant_key": {
+          "name": "uq_settings_tenant_key",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.super_admin_audit_log": {
+      "name": "super_admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_super_admin_audit_actor_occurred": {
+          "name": "idx_super_admin_audit_actor_occurred",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_super_admin_audit_target_occurred": {
+          "name": "idx_super_admin_audit_target_occurred",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_super_admin_audit_batch": {
+          "name": "idx_super_admin_audit_batch",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "super_admin_audit_log_actor_user_id_auth_user_id_fk": {
+          "name": "super_admin_audit_log_actor_user_id_auth_user_id_fk",
+          "tableFrom": "super_admin_audit_log",
+          "tableTo": "auth_user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_setting": {
+      "name": "system_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_system_setting_key": {
+          "name": "uq_system_setting_key",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_cleanup_batch": {
+      "name": "tenant_cleanup_batch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inactive_months": {
+          "name": "inactive_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "candidate_count": {
+          "name": "candidate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_count": {
+          "name": "deleted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tenant_cleanup_batch_created": {
+          "name": "idx_tenant_cleanup_batch_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_cleanup_batch_actor_user_id_auth_user_id_fk": {
+          "name": "tenant_cleanup_batch_actor_user_id_auth_user_id_fk",
+          "tableFrom": "tenant_cleanup_batch",
+          "tableTo": "auth_user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_cleanup_item": {
+      "name": "tenant_cleanup_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_slug": {
+          "name": "tenant_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_tenant_cleanup_item_batch_status": {
+          "name": "idx_tenant_cleanup_item_batch_status",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_cleanup_item_batch_id_tenant_cleanup_batch_id_fk": {
+          "name": "tenant_cleanup_item_batch_id_tenant_cleanup_batch_id_fk",
+          "tableFrom": "tenant_cleanup_item",
+          "tableTo": "tenant_cleanup_batch",
+          "columnsFrom": ["batch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tenant_cleanup_item_batch_tenant": {
+          "name": "uq_tenant_cleanup_item_batch_tenant",
+          "nullsNotDistinct": false,
+          "columns": ["batch_id", "tenant_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_domain": {
+      "name": "tenant_domain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tenant_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cloudflare_hostname_id": {
+          "name": "cloudflare_hostname_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname_status": {
+          "name": "hostname_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssl_status": {
+          "name": "ssl_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_errors": {
+          "name": "verification_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tenant_domain_tenant": {
+          "name": "idx_tenant_domain_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_domain_tenant_id_tenant_id_fk": {
+          "name": "tenant_domain_tenant_id_tenant_id_fk",
+          "tableFrom": "tenant_domain",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tenant_domain_domain": {
+          "name": "uq_tenant_domain_domain",
+          "nullsNotDistinct": false,
+          "columns": ["domain"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_membership": {
+      "name": "tenant_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "tenant_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_tenant_membership_active_owner": {
+          "name": "uq_tenant_membership_active_owner",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tenant_membership\".\"role\" = 'owner' and \"tenant_membership\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tenant_membership_user_status": {
+          "name": "idx_tenant_membership_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tenant_membership_tenant_role_status": {
+          "name": "idx_tenant_membership_tenant_role_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_membership_tenant_id_tenant_id_fk": {
+          "name": "tenant_membership_tenant_id_tenant_id_fk",
+          "tableFrom": "tenant_membership",
+          "tableTo": "tenant",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_membership_user_id_auth_user_id_fk": {
+          "name": "tenant_membership_user_id_auth_user_id_fk",
+          "tableFrom": "tenant_membership",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tenant_membership_tenant_user": {
+          "name": "uq_tenant_membership_tenant_user",
+          "nullsNotDistinct": false,
+          "columns": ["tenant_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant": {
+      "name": "tenant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "storage_plan_id": {
+          "name": "storage_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tenant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tenant_slug": {
+          "name": "uq_tenant_slug",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_block": {
+      "name": "user_block",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blocker_user_id": {
+          "name": "blocker_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_user_id": {
+          "name": "blocked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_block_blocker": {
+          "name": "idx_user_block_blocker",
+          "columns": [
+            {
+              "expression": "blocker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_block_blocked": {
+          "name": "idx_user_block_blocked",
+          "columns": [
+            {
+              "expression": "blocked_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_block_blocker_user_id_auth_user_id_fk": {
+          "name": "user_block_blocker_user_id_auth_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "auth_user",
+          "columnsFrom": ["blocker_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_block_blocked_user_id_auth_user_id_fk": {
+          "name": "user_block_blocked_user_id_auth_user_id_fk",
+          "tableFrom": "user_block",
+          "tableTo": "auth_user",
+          "columnsFrom": ["blocked_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_block_pair": {
+          "name": "uq_user_block_pair",
+          "nullsNotDistinct": false,
+          "columns": ["blocker_user_id", "blocked_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_deletion_stage": {
+      "name": "account_deletion_stage",
+      "schema": "public",
+      "values": ["revoke_providers", "resolve_billing", "delete_storage", "finalize_database", "completed"]
+    },
+    "public.account_deletion_status": {
+      "name": "account_deletion_status",
+      "schema": "public",
+      "values": ["requested", "processing", "retryable_failure", "manual_intervention", "completed"]
+    },
+    "public.apns_environment": {
+      "name": "apns_environment",
+      "schema": "public",
+      "values": ["development", "production"]
+    },
+    "public.apple_authorization_status": {
+      "name": "apple_authorization_status",
+      "schema": "public",
+      "values": ["active", "revoked", "revocation_failed"]
+    },
+    "public.billing_entitlement_kind": {
+      "name": "billing_entitlement_kind",
+      "schema": "public",
+      "values": ["application_plan", "managed_storage"]
+    },
+    "public.billing_entitlement_source": {
+      "name": "billing_entitlement_source",
+      "schema": "public",
+      "values": ["subscription", "manual"]
+    },
+    "public.billing_entitlement_status": {
+      "name": "billing_entitlement_status",
+      "schema": "public",
+      "values": ["active", "inactive"]
+    },
+    "public.billing_provider": {
+      "name": "billing_provider",
+      "schema": "public",
+      "values": ["creem", "app_store"]
+    },
+    "public.billing_provider_event_status": {
+      "name": "billing_provider_event_status",
+      "schema": "public",
+      "values": ["pending", "processed", "failed"]
+    },
+    "public.billing_subscription_status": {
+      "name": "billing_subscription_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "grace_period",
+        "billing_retry",
+        "cancel_scheduled",
+        "expired",
+        "revoked",
+        "conflict"
+      ]
+    },
+    "public.comment_status": {
+      "name": "comment_status",
+      "schema": "public",
+      "values": ["pending", "approved", "rejected", "hidden"]
+    },
+    "public.content_report_status": {
+      "name": "content_report_status",
+      "schema": "public",
+      "values": ["pending", "reviewed", "dismissed", "actioned"]
+    },
+    "public.mobile_storage_handoff_status": {
+      "name": "mobile_storage_handoff_status",
+      "schema": "public",
+      "values": ["issued", "exchanged", "completed", "expired"]
+    },
+    "public.photo_sync_status": {
+      "name": "photo_sync_status",
+      "schema": "public",
+      "values": ["pending", "synced", "conflict"]
+    },
+    "public.platform_role": {
+      "name": "platform_role",
+      "schema": "public",
+      "values": ["user", "superadmin"]
+    },
+    "public.tenant_domain_status": {
+      "name": "tenant_domain_status",
+      "schema": "public",
+      "values": ["pending", "verified", "disabled"]
+    },
+    "public.tenant_membership_role": {
+      "name": "tenant_membership_role",
+      "schema": "public",
+      "values": ["member", "admin", "owner"]
+    },
+    "public.tenant_membership_status": {
+      "name": "tenant_membership_status",
+      "schema": "public",
+      "values": ["active", "suspended"]
+    },
+    "public.tenant_status": {
+      "name": "tenant_status",
+      "schema": "public",
+      "values": ["pending", "active", "inactive", "suspended"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/be/packages/db/migrations/meta/_journal.json
+++ b/be/packages/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1787072893843,
       "tag": "0025_premium_scorpion",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1787395553951,
+      "tag": "0026_overjoyed_marauders",
+      "breakpoints": true
     }
   ]
 }

--- a/be/packages/db/src/schema.ts
+++ b/be/packages/db/src/schema.ts
@@ -36,6 +36,7 @@ export const tenantStatusEnum = pgEnum('tenant_status', ['pending', 'active', 'i
 export const tenantDomainStatusEnum = pgEnum('tenant_domain_status', ['pending', 'verified', 'disabled'])
 export const photoSyncStatusEnum = pgEnum('photo_sync_status', ['pending', 'synced', 'conflict'])
 export const commentStatusEnum = pgEnum('comment_status', ['pending', 'approved', 'rejected', 'hidden'])
+export const contentReportStatusEnum = pgEnum('content_report_status', ['pending', 'reviewed', 'dismissed', 'actioned'])
 export const apnsEnvironmentEnum = pgEnum('apns_environment', ['development', 'production'])
 export const appleAuthorizationStatusEnum = pgEnum('apple_authorization_status', [
   'active',
@@ -643,6 +644,53 @@ export const commentReactions = pgTable(
   ],
 )
 
+export const contentReports = pgTable(
+  'content_report',
+  {
+    id: snowflakeId,
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id, { onDelete: 'cascade' }),
+    commentId: text('comment_id').references(() => comments.id, { onDelete: 'set null' }),
+    reporterUserId: text('reporter_user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    reportedUserId: text('reported_user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    reason: text('reason').notNull(),
+    details: text('details'),
+    contentSnapshot: text('content_snapshot').notNull(),
+    status: contentReportStatusEnum('status').notNull().default('pending'),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  t => [
+    unique('uq_content_report_reporter_comment').on(t.reporterUserId, t.commentId),
+    index('idx_content_report_tenant_status').on(t.tenantId, t.status, t.createdAt),
+    index('idx_content_report_reported_user').on(t.reportedUserId, t.createdAt),
+  ],
+)
+
+export const userBlocks = pgTable(
+  'user_block',
+  {
+    id: snowflakeId,
+    blockerUserId: text('blocker_user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    blockedUserId: text('blocked_user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    createdAt: timestamp('created_at', { mode: 'string' }).defaultNow().notNull(),
+  },
+  t => [
+    unique('uq_user_block_pair').on(t.blockerUserId, t.blockedUserId),
+    index('idx_user_block_blocker').on(t.blockerUserId, t.createdAt),
+    index('idx_user_block_blocked').on(t.blockedUserId, t.createdAt),
+  ],
+)
+
 export const managedStorageUsages = pgTable(
   'managed_storage_usage',
   {
@@ -879,6 +927,8 @@ export const dbSchema = {
   reactions,
   comments,
   commentReactions,
+  contentReports,
+  userBlocks,
   managedStorageUsages,
   managedStorageFileReferences,
   photoAssets,


### PR DESCRIPTION
## Summary

- require explicit Terms of Use and Privacy Policy consent before every native sign-in path
- add comment reporting and user blocking with immediate optimistic removal on iOS
- persist reports and blocks, filter blocked authors from comments and gallery feeds, and notify administrators
- add the database migration and behavior-focused regression tests

## Validation

- pnpm --filter @afilmory/core build
- pnpm exec vitest run be/apps/core/src/modules/platform/user-safety/user-safety.policy.spec.ts
- pnpm --filter @afilmory/mobile native:test (207 passed, 1 skipped)
- targeted ESLint and git diff --check
- iPhone 17 Pro / iOS 26.5 Simulator interaction acceptance

## App Review follow-up

The UGC and legal-consent findings are addressed. Sponsor remains externally blocked until the account holder completes App Store Connect banking and U.S. tax information and the Paid Apps Agreement becomes active. Apple also requested a physical-device recording before resubmission.