### PR TITLE
fix: render XMP regions and floating labels

### DIFF
--- a/apps/web/src/modules/metadata/ExifPanel.tsx
+++ b/apps/web/src/modules/metadata/ExifPanel.tsx
@@ -137,6 +137,7 @@ export const ExifPanelContent: FC<ExifPanelContentProps> = ({
         currentPhoto.width,
         currentPhoto.height,
         currentPhoto.exif?.Orientation,
+        currentPhoto.exif?.RegionInfo,
       ),
     [currentPhoto],
   )

--- a/apps/web/src/modules/viewer/PhotoRegionsOverlay.test.ts
+++ b/apps/web/src/modules/viewer/PhotoRegionsOverlay.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import type { PhotoRegion } from '@afilmory/builder'
 import { it } from 'vitest'
 
-import { getRenderablePhotoRegions } from './photo-region-bounds'
+import { getFloatingLabelPosition, getRenderablePhotoRegions } from './photo-region-bounds'
 
 it('getRenderablePhotoRegions excludes metadata-only and zero-area regions from viewer controls', () => {
   const regions: PhotoRegion[] = [
@@ -70,4 +70,9 @@ it('getRenderablePhotoRegions restores missing area data from XMP metadata', () 
       },
     ],
   )
+})
+
+it('places floating labels below regions near the overlay top edge', () => {
+  assert.equal(getFloatingLabelPosition(0.02, 1000), 'below')
+  assert.equal(getFloatingLabelPosition(0.1, 1000), 'above')
 })

--- a/apps/web/src/modules/viewer/PhotoRegionsOverlay.test.ts
+++ b/apps/web/src/modules/viewer/PhotoRegionsOverlay.test.ts
@@ -44,3 +44,30 @@ it('getRenderablePhotoRegions uses the photo dimensions when pixel regions omit 
   assert.deepEqual(getRenderablePhotoRegions([region]), [])
   assert.deepEqual(getRenderablePhotoRegions([region], 6000, 4000), [region])
 })
+
+it('getRenderablePhotoRegions restores missing area data from XMP metadata', () => {
+  const region: PhotoRegion = {
+    name: '家鸦',
+    type: 'Face',
+    area: null,
+    appliedToDimensions: { width: 5376, height: 4032, unit: 'pixel' },
+  }
+
+  assert.deepEqual(
+    getRenderablePhotoRegions([region], 5376, 4032, undefined, {
+      RegionList: [
+        {
+          Name: '家鸦',
+          Type: 'Face',
+          Area: { X: 0.45925, Y: 0.51667, W: 0.26389, H: 0.35185 },
+        },
+      ],
+    }),
+    [
+      {
+        ...region,
+        area: { x: 0.45925, y: 0.51667, width: 0.26389, height: 0.35185, unit: 'normalized' },
+      },
+    ],
+  )
+})

--- a/apps/web/src/modules/viewer/PhotoRegionsOverlay.tsx
+++ b/apps/web/src/modules/viewer/PhotoRegionsOverlay.tsx
@@ -1,10 +1,10 @@
 import type { PhotoRegion } from '@afilmory/builder'
 import { clsxm } from '@afilmory/utils'
 import type { CSSProperties } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import type { PhotoRegionBounds } from './photo-region-bounds'
-import { getPhotoRegionBounds } from './photo-region-bounds'
+import { getFloatingLabelPosition, getPhotoRegionBounds } from './photo-region-bounds'
 import { getPhotoRegionIcon, getPhotoRegionId } from './photo-region-display'
 
 interface PhotoRegionsOverlayProps {
@@ -13,6 +13,7 @@ interface PhotoRegionsOverlayProps {
   photoHeight?: number
   orientation?: number
   accentColor?: string
+  labelPlacement?: 'edge' | 'floating'
   activeRegionId?: string | null
   showAllBoxes?: boolean
   interactive?: boolean
@@ -32,19 +33,27 @@ export const PhotoRegionsOverlay = ({
   photoHeight,
   orientation,
   accentColor,
+  labelPlacement = 'edge',
   activeRegionId,
   showAllBoxes = false,
   interactive = true,
   onActiveRegionChange,
 }: PhotoRegionsOverlayProps) => {
   const [localActiveRegionId, setLocalActiveRegionId] = useState<string | null>(null)
+  const [overlayHeight, setOverlayHeight] = useState(0)
+  const overlayRef = useRef<HTMLDivElement>(null)
   const resolvedActiveRegionId = activeRegionId === undefined ? localActiveRegionId : activeRegionId
 
   useEffect(() => {
-    if (!interactive) {
-      setLocalActiveRegionId(null)
+    const overlay = overlayRef.current
+    if (!overlay) {
+      return
     }
-  }, [interactive])
+
+    const observer = new ResizeObserver(entries => setOverlayHeight(entries[0]?.contentRect.height ?? 0))
+    observer.observe(overlay)
+    return () => observer.disconnect()
+  }, [])
 
   const setActiveRegion = (regionId: string | null) => {
     if (activeRegionId === undefined) {
@@ -90,7 +99,7 @@ export const PhotoRegionsOverlay = ({
   const accentStyle = accentColor ? ({ '--color-accent': accentColor } as CSSProperties) : undefined
 
   return (
-    <div className="pointer-events-none absolute inset-0 z-20" style={accentStyle}>
+    <div ref={overlayRef} className="pointer-events-none absolute inset-0 z-20" style={accentStyle}>
       {regionViews.map((region) => {
         const isActive = resolvedActiveRegionId === region.id
         const isMuted = showAllBoxes && hasActiveRegion && !isActive
@@ -98,6 +107,8 @@ export const PhotoRegionsOverlay = ({
         const showLabel = showAllBoxes || isActive
         const primaryLabel = region.name || region.type
         const secondaryLabel = region.name ? region.type : undefined
+        const isFloatingLabelBelow
+          = labelPlacement === 'floating' && getFloatingLabelPosition(region.bounds.top, overlayHeight) === 'below'
 
         return (
           <div
@@ -137,7 +148,12 @@ export const PhotoRegionsOverlay = ({
             {primaryLabel && (
               <div
                 className={clsxm(
-                  'pointer-events-none absolute top-0 left-0 z-30 max-w-[min(22rem,80vw)] -translate-y-1/2 transition-opacity duration-200',
+                  'pointer-events-none absolute z-30 max-w-[min(22rem,80vw)] transition-opacity duration-200',
+                  labelPlacement === 'floating'
+                    ? isFloatingLabelBelow
+                      ? 'top-full left-1/2 -translate-x-1/2 translate-y-1.5'
+                      : 'top-0 left-1/2 -translate-x-1/2 -translate-y-[calc(100%+0.375rem)]'
+                    : 'top-0 left-0 -translate-y-1/2',
                   showLabel ? (isMuted ? 'opacity-45' : 'opacity-100') : 'opacity-0',
                 )}
               >

--- a/apps/web/src/modules/viewer/PhotoViewer.tsx
+++ b/apps/web/src/modules/viewer/PhotoViewer.tsx
@@ -101,6 +101,7 @@ export const PhotoViewer = ({
   )
   const hasRegions = currentRegions.length > 0
   const regionAccentSource = siteConfig.viewer?.regions?.accentSource ?? 'system'
+  const regionLabelPlacement = siteConfig.viewer?.regions?.labelPlacement ?? 'edge'
 
   useEffect(() => {
     setActiveRegionId(null)
@@ -655,6 +656,7 @@ export const PhotoViewer = ({
                                     )}
                                     regionOrientation={photo.exif?.Orientation}
                                     regionAccentColor={regionAccentColor}
+                                    regionLabelPlacement={regionLabelPlacement}
                                     activeRegionId={isCurrentImage ? activeRegionId : null}
                                     showAllRegions={isCurrentImage ? showAllRegions : false}
                                     enableRegionHover={isCurrentImage && canHoverRegions}

--- a/apps/web/src/modules/viewer/PhotoViewer.tsx
+++ b/apps/web/src/modules/viewer/PhotoViewer.tsx
@@ -94,6 +94,7 @@ export const PhotoViewer = ({
             currentPhoto.width,
             currentPhoto.height,
             currentPhoto.exif?.Orientation,
+            currentPhoto.exif?.RegionInfo,
           )
         : [],
     [currentPhoto],
@@ -645,7 +646,13 @@ export const PhotoViewer = ({
                                           : { type: 'none' }
                                     }
                                     shouldAutoPlayVideoOnce={isCurrentImage}
-                                    regions={isCurrentImage ? currentRegions : photo.regions}
+                                    regions={getRenderablePhotoRegions(
+                                      photo.regions,
+                                      photo.width,
+                                      photo.height,
+                                      photo.exif?.Orientation,
+                                      photo.exif?.RegionInfo,
+                                    )}
                                     regionOrientation={photo.exif?.Orientation}
                                     regionAccentColor={regionAccentColor}
                                     activeRegionId={isCurrentImage ? activeRegionId : null}

--- a/apps/web/src/modules/viewer/ProgressiveImage.tsx
+++ b/apps/web/src/modules/viewer/ProgressiveImage.tsx
@@ -56,6 +56,7 @@ export const ProgressiveImage = ({
   regions = [],
   regionOrientation,
   regionAccentColor,
+  regionLabelPlacement,
   activeRegionId,
   showAllRegions = false,
   enableRegionHover = true,
@@ -366,6 +367,7 @@ export const ProgressiveImage = ({
               photoHeight={height}
               orientation={regionOrientation}
               accentColor={regionAccentColor}
+              labelPlacement={regionLabelPlacement}
               activeRegionId={activeRegionId}
               showAllBoxes={showAllRegions}
               interactive={enableRegionHover}
@@ -419,6 +421,7 @@ export const ProgressiveImage = ({
                   photoHeight={height}
                   orientation={regionOrientation}
                   accentColor={regionAccentColor}
+                  labelPlacement={regionLabelPlacement}
                   activeRegionId={activeRegionId}
                   showAllBoxes={showAllRegions}
                   interactive={enableRegionHover}
@@ -475,6 +478,7 @@ export const ProgressiveImage = ({
                       photoHeight={height}
                       orientation={regionOrientation}
                       accentColor={regionAccentColor}
+                      labelPlacement={regionLabelPlacement}
                       activeRegionId={activeRegionId}
                       showAllBoxes={showAllRegions}
                       interactive={enableRegionHover}

--- a/apps/web/src/modules/viewer/photo-region-bounds.ts
+++ b/apps/web/src/modules/viewer/photo-region-bounds.ts
@@ -142,3 +142,7 @@ function normalizeBounds(bounds: PhotoRegionBounds): PhotoRegionBounds | null {
     height,
   }
 }
+
+export function getFloatingLabelPosition(regionTop: number, overlayHeight: number): 'above' | 'below' {
+  return regionTop * overlayHeight < 34 ? 'below' : 'above'
+}

--- a/apps/web/src/modules/viewer/photo-region-bounds.ts
+++ b/apps/web/src/modules/viewer/photo-region-bounds.ts
@@ -1,4 +1,5 @@
 import type { PhotoRegion } from '@afilmory/builder'
+import type { ExiftoolXmpRegion, ExiftoolXmpRegionInfo } from '@afilmory/typing'
 
 export interface PhotoRegionBounds {
   left: number
@@ -42,8 +43,27 @@ export function getRenderablePhotoRegions(
   photoWidth?: number,
   photoHeight?: number,
   orientation?: number,
+  regionInfo?: ExiftoolXmpRegionInfo,
 ) {
-  return regions.filter(region => getPhotoRegionBounds(region, photoWidth, photoHeight, orientation) !== null)
+  return regions
+    .map((region, index) => getRegionWithExifArea(region, regionInfo?.RegionList?.[index]))
+    .filter(region => getPhotoRegionBounds(region, photoWidth, photoHeight, orientation) !== null)
+}
+
+function getRegionWithExifArea(region: PhotoRegion, exifRegion?: ExiftoolXmpRegion): PhotoRegion {
+  if (region.area || !exifRegion?.Area) {
+    return region
+  }
+
+  const { X: x, Y: y, W: width, H: height, Unit: unit } = exifRegion.Area
+  if (typeof x !== 'number' || typeof y !== 'number' || typeof width !== 'number' || typeof height !== 'number') {
+    return region
+  }
+
+  return {
+    ...region,
+    area: { x, y, width, height, unit: unit ?? 'normalized' },
+  }
 }
 
 function getPixelBounds(

--- a/apps/web/src/modules/viewer/types.ts
+++ b/apps/web/src/modules/viewer/types.ts
@@ -48,6 +48,7 @@ export interface ProgressiveImageProps {
   regions?: PhotoRegion[]
   regionOrientation?: number
   regionAccentColor?: string
+  regionLabelPlacement?: 'edge' | 'floating'
   activeRegionId?: string | null
   showAllRegions?: boolean
   enableRegionHover?: boolean

--- a/be/apps/core/src/locales/ui-schema/en.ts
+++ b/be/apps/core/src/locales/ui-schema/en.ts
@@ -173,6 +173,17 @@ const enUiSchema = {
           },
         },
       },
+      viewer: {
+        title: 'Viewer regions',
+        description: 'Control how labels are positioned for regions detected in a photo.',
+        fields: {
+          'region-label-placement': {
+            title: 'Region label placement',
+            description:
+              'Edge keeps the label attached to the region corner; Floating centers it above the region and moves it below when needed.',
+          },
+        },
+      },
       map: {
         title: 'Map display',
         description: 'Configure providers, style, and projection for the map component.',

--- a/be/apps/core/src/locales/ui-schema/zh-CN.ts
+++ b/be/apps/core/src/locales/ui-schema/zh-CN.ts
@@ -172,6 +172,16 @@ const zhCnUiSchema = {
           },
         },
       },
+      viewer: {
+        title: '查看器区域',
+        description: '控制照片中标记区域的标签位置。',
+        fields: {
+          'region-label-placement': {
+            title: '区域标签位置',
+            description: '边缘会将标签固定在区域角落；悬浮会将标签居中显示在区域上方，空间不足时移至下方。',
+          },
+        },
+      },
       map: {
         title: '地图展示',
         description: '配置地图组件可用的提供商、样式与投影。',

--- a/be/apps/core/src/modules/configuration/setting/setting.constant.ts
+++ b/be/apps/core/src/modules/configuration/setting/setting.constant.ts
@@ -38,7 +38,8 @@ function createJsonStringArraySchema(options: {
         return z.NEVER
       }
       return JSON.stringify(parsed)
-    } catch {
+    }
+    catch {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: options.errorMessage,
@@ -70,7 +71,7 @@ export const DEFAULT_SETTING_DEFINITIONS = {
   },
   'builder.storage.activeProvider': {
     isSensitive: false,
-    schema: z.string().transform((value) => value.trim()),
+    schema: z.string().transform(value => value.trim()),
   },
   [BUILDER_SYSTEM_CONFIG_SETTING_KEY]: {
     isSensitive: false,
@@ -116,6 +117,22 @@ export const DEFAULT_SETTING_DEFINITIONS = {
             message: 'Accent color must be a valid hex color',
           })
         }
+      }),
+  },
+  'site.viewer.regions.labelPlacement': {
+    isSensitive: false,
+    schema: z
+      .string()
+      .trim()
+      .superRefine((value, ctx) => {
+        if (value.length === 0 || value === 'edge' || value === 'floating') {
+          return
+        }
+
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Region label placement must be either edge or floating',
+        })
       }),
   },
   'site.social.twitter': {

--- a/be/apps/core/src/modules/configuration/site-setting/site-setting.service.ts
+++ b/be/apps/core/src/modules/configuration/site-setting/site-setting.service.ts
@@ -65,7 +65,7 @@ export class SiteSettingService {
       return
     }
 
-    const normalizedEntries = entries.map((entry) => ({
+    const normalizedEntries = entries.map(entry => ({
       ...entry,
       value: typeof entry.value === 'string' ? entry.value : String(entry.value),
     })) as readonly SettingEntryInput[]
@@ -85,16 +85,22 @@ export class SiteSettingService {
       author: { ...DEFAULT_SITE_CONFIG.author },
     }
 
-    assignString(values['site.name'], (value) => (config.name = value))
-    assignString(values['site.title'], (value) => (config.title = value))
-    assignString(values['site.description'], (value) => (config.description = value))
-    assignString(values['site.url'], (value) => (config.url = value))
-    assignString(values['site.accentColor'], (value) => (config.accentColor = value))
+    assignString(values['site.name'], value => (config.name = value))
+    assignString(values['site.title'], value => (config.title = value))
+    assignString(values['site.description'], value => (config.description = value))
+    assignString(values['site.url'], value => (config.url = value))
+    assignString(values['site.accentColor'], value => (config.accentColor = value))
+
+    const viewer = buildViewerConfig(values)
+    if (viewer) {
+      config.viewer = viewer
+    }
 
     const resolvedAuthor = await this.resolveAuthorFromTenant(config.name)
     if (resolvedAuthor) {
       config.author = resolvedAuthor
-    } else if (!config.author.name) {
+    }
+    else if (!config.author.name) {
       config.author.name = config.name
     }
 
@@ -113,7 +119,7 @@ export class SiteSettingService {
       config.map = mapProviders
     }
 
-    assignString(values['site.mapStyle'], (value) => (config.mapStyle = value))
+    assignString(values['site.mapStyle'], value => (config.mapStyle = value))
 
     const projection = normalizeMapProjection(values['site.mapProjection'])
     if (projection) {
@@ -181,11 +187,11 @@ export class SiteSettingService {
     }
 
     const fallbackName = normalizeStringToUndefined(siteName) ?? siteName
-    const normalizedName =
-      normalizeStringToUndefined(user.displayUsername) ??
-      normalizeStringToUndefined(user.username) ??
-      normalizeStringToUndefined(user.name) ??
-      fallbackName
+    const normalizedName
+      = normalizeStringToUndefined(user.displayUsername)
+        ?? normalizeStringToUndefined(user.username)
+        ?? normalizeStringToUndefined(user.name)
+        ?? fallbackName
 
     const author: SiteConfigAuthor = {
       name: normalizedName,
@@ -242,7 +248,8 @@ export class SiteSettingService {
         throw new Error('Invalid protocol')
       }
       return url.toString()
-    } catch {
+    }
+    catch {
       throw new BizException(ErrorCode.COMMON_VALIDATION, {
         message: '头像链接必须是以 http(s) 或 // 开头的有效 URL',
       })
@@ -332,6 +339,12 @@ interface SiteConfigFeed {
   }
 }
 
+interface SiteConfigViewer {
+  regions?: {
+    labelPlacement?: 'edge' | 'above' | 'floating'
+  }
+}
+
 type SiteConfigMapProviders = string[]
 
 type SiteConfigProjection = 'globe' | 'mercator'
@@ -343,6 +356,7 @@ interface SiteConfig {
   url: string
   accentColor: string
   author: SiteConfigAuthor
+  viewer?: SiteConfigViewer
   social?: SiteConfigSocial
   feed?: SiteConfigFeed
   map?: SiteConfigMapProviders
@@ -390,9 +404,10 @@ function parseJsonStringArray(value: string | null | undefined): string[] | unde
       return undefined
     }
 
-    const result = parsed.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry.trim())
+    const result = parsed.filter((entry): entry is string => typeof entry === 'string').map(entry => entry.trim())
     return result.length > 0 ? result : undefined
-  } catch {
+  }
+  catch {
     return undefined
   }
 }
@@ -440,4 +455,14 @@ function normalizeMapProjection(value: string | null | undefined): SiteConfig['m
   }
 
   return undefined
+}
+
+function buildViewerConfig(values: SiteSettingValueMap): SiteConfigViewer | undefined {
+  const labelPlacement = normalizeRegionLabelPlacement(values['site.viewer.regions.labelPlacement'])
+  return labelPlacement ? { regions: { labelPlacement } } : undefined
+}
+
+function normalizeRegionLabelPlacement(value: string | null | undefined): 'edge' | 'floating' | undefined {
+  const normalized = normalizeStringToUndefined(value)
+  return normalized === 'edge' || normalized === 'floating' ? normalized : undefined
 }

--- a/be/apps/core/src/modules/configuration/site-setting/site-setting.type.ts
+++ b/be/apps/core/src/modules/configuration/site-setting/site-setting.type.ts
@@ -8,6 +8,7 @@ export const SITE_SETTING_KEYS = [
   'site.description',
   'site.url',
   'site.accentColor',
+  'site.viewer.regions.labelPlacement',
   'site.social.twitter',
   'site.social.github',
   'site.feed.folo.challenge.feedId',

--- a/be/apps/core/src/modules/configuration/site-setting/site-setting.ui-schema.ts
+++ b/be/apps/core/src/modules/configuration/site-setting/site-setting.ui-schema.ts
@@ -182,6 +182,28 @@ export function createSiteSettingUiSchema(t: UiSchemaTFunction): UiSchema<SiteSe
       },
       {
         type: 'section',
+        id: 'site-viewer',
+        title: t('site.sections.viewer.title'),
+        description: t('site.sections.viewer.description'),
+        icon: 'scan',
+        children: [
+          {
+            type: 'field',
+            id: 'site-viewer-region-label-placement',
+            title: t('site.sections.viewer.fields.region-label-placement.title'),
+            description: t('site.sections.viewer.fields.region-label-placement.description'),
+            key: 'site.viewer.regions.labelPlacement',
+            component: {
+              type: 'select',
+              options: ['edge', 'floating'],
+              presentation: 'segmented',
+            },
+            icon: 'tag',
+          },
+        ],
+      },
+      {
+        type: 'section',
         id: 'site-map',
         title: t('site.sections.map.title'),
         description: t('site.sections.map.description'),

--- a/config.example.json
+++ b/config.example.json
@@ -6,7 +6,8 @@
   "accentColor": "#007bff",
   "viewer": {
     "regions": {
-      "accentSource": "system"
+      "accentSource": "system",
+      "labelPlacement": "edge"
     }
   },
   "author": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,12 +9,14 @@
 - `map`: e.g. `["maplibre"]`
 - `mapStyle`: `builtin` or provider style
 - `mapProjection`: `globe` or `mercator`
+- `viewer.regions.labelPlacement`: `edge` (default, label at the region corner) or `floating` (label centered above the region and moved below when needed)
 
 `config.json` merges into `site.config.ts` and is used by both SPA and SSR.
 
 ## Builder Config (`builder.config.ts`)
 
-Use `defineBuilderConfig` from `@afilmory/builder`. Recommended structure (see `builder.config.default.ts`):
+Use `defineBuilderConfig` from `@afilmory/builder`.
+Recommended structure (see `builder.config.default.ts`):
 
 - **storage**: provider (`s3`, `b2`, `github`, `local`, `eagle`), credentials, prefix, custom domain, `excludeRegex`, concurrency.
 - **system.processing**: `defaultConcurrency`, `enableLivePhotoDetection`, `digestSuffixLength`.

--- a/packages/builder/src/image/exif.ts
+++ b/packages/builder/src/image/exif.ts
@@ -1,7 +1,16 @@
+import type { Buffer } from 'node:buffer'
 import { mkdir, unlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import process from 'node:process'
 
-import type { ExiftoolXmpArea, ExiftoolXmpDimensions, ExiftoolXmpRegionInfo, PhotoRegion, PhotoXmpMetadata, PickedExif } from '@afilmory/typing'
+import type {
+  ExiftoolXmpArea,
+  ExiftoolXmpDimensions,
+  ExiftoolXmpRegionInfo,
+  PhotoRegion,
+  PhotoXmpMetadata,
+  PickedExif,
+} from '@afilmory/typing'
 import { isNil, noop } from 'es-toolkit'
 import type { ExifDateTime, Tags } from 'exiftool-vendored'
 import { ExifTool } from 'exiftool-vendored'
@@ -60,10 +69,12 @@ export async function extractExifData(imageBuffer: Buffer, originalBuffer?: Buff
 
     log.success('EXIF 数据提取完成')
     return result
-  } catch (error) {
+  }
+  catch (error) {
     log.error('提取 EXIF 数据失败:', error)
     return null
-  } finally {
+  }
+  finally {
     await unlink(tempImagePath).catch(noop)
   }
 }
@@ -246,24 +257,22 @@ function parseRegionInfo(regionInfo: ExiftoolXmpRegionInfo | undefined): PhotoRe
 
   const appliedToDimensions = parseAppliedToDimensions(regionInfo.AppliedToDimensions)
 
-  return regionInfo.RegionList
-    .map((region) => {
-      const name = typeof region.Name === 'string' ? region.Name.trim() : ''
-      const type = normalizeRegionType(region.Type)
-      const area = parseRegionArea(region.Area)
+  return regionInfo.RegionList.map((region) => {
+    const name = typeof region.Name === 'string' ? region.Name.trim() : ''
+    const type = normalizeRegionType(region.Type)
+    const area = parseRegionArea(region.Area)
 
-      if (!name && !type && !area) {
-        return null
-      }
+    if (!name && !type && !area) {
+      return null
+    }
 
-      return {
-        name,
-        ...(type ? { type } : {}),
-        area,
-        appliedToDimensions,
-      } satisfies PhotoRegion
-    })
-    .filter((region): region is PhotoRegion => region !== null)
+    return {
+      name,
+      ...(type ? { type } : {}),
+      area,
+      appliedToDimensions,
+    } satisfies PhotoRegion
+  }).filter((region): region is PhotoRegion => region !== null)
 }
 
 function parseAppliedToDimensions(dimensions: ExiftoolXmpDimensions | undefined) {
@@ -279,11 +288,12 @@ function parseAppliedToDimensions(dimensions: ExiftoolXmpDimensions | undefined)
 }
 
 function parseRegionArea(area: ExiftoolXmpArea | undefined) {
-  if (!area?.Unit) {
-    return null
-  }
-
-  if (typeof area.X !== 'number' || typeof area.Y !== 'number' || typeof area.W !== 'number' || typeof area.H !== 'number') {
+  if (
+    typeof area?.X !== 'number'
+    || typeof area.Y !== 'number'
+    || typeof area.W !== 'number'
+    || typeof area.H !== 'number'
+  ) {
     return null
   }
 
@@ -292,7 +302,7 @@ function parseRegionArea(area: ExiftoolXmpArea | undefined) {
     y: area.Y,
     width: area.W,
     height: area.H,
-    unit: area.Unit,
+    unit: area.Unit ?? 'normalized',
   }
 }
 
@@ -311,7 +321,7 @@ function normalizeStringArray(input: string[] | undefined): string[] {
     return []
   }
 
-  return input.map((value) => value.trim()).filter(Boolean)
+  return input.map(value => value.trim()).filter(Boolean)
 }
 
 function mergeUniqueStrings(...groups: string[][]): string[] {

--- a/site.config.ts
+++ b/site.config.ts
@@ -82,6 +82,7 @@ interface Social {
 interface ViewerConfig {
   regions?: {
     accentSource?: 'system' | 'photo'
+    labelPlacement?: 'edge' | 'floating'
   }
 }
 
@@ -94,6 +95,7 @@ const defaultConfig: SiteConfig = {
   viewer: {
     regions: {
       accentSource: 'system',
+      labelPlacement: 'edge',
     },
   },
   author: {


### PR DESCRIPTION
- Restore renderable XMP region coordinates when Lightroom omits their unit, so affected photo regions appear in the viewer and inspector.
- Add configurable `edge` and adaptive `floating` label placements, preventing long labels on small regions from overflowing while keeping the existing edge placement as the default.