### PR TITLE
fix(billing): remove 100-image hard limit for BYO storage (fix #268)

### DIFF
--- a/be/apps/core/src/modules/content/manifest/manifest.public.controller.ts
+++ b/be/apps/core/src/modules/content/manifest/manifest.public.controller.ts
@@ -33,7 +33,11 @@ const SearchPhotosSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .optional(),
   sort: z.enum(['asc', 'desc']).optional(),
-  limit: z.number().int().positive().max(100).optional(),
+  // Fix #268: 100 was a hard browsing cap that made galleries with >100
+  // photos appear truncated even when quotas allowed more. Raise to a
+  // defensible page-size ceiling; callers needing more should paginate via
+  // offset.
+  limit: z.number().int().positive().max(5000).optional(),
   offset: z.number().int().nonnegative().optional(),
 })
 

--- a/be/apps/core/src/modules/content/photo/assets/photo-asset.service.ts
+++ b/be/apps/core/src/modules/content/photo/assets/photo-asset.service.ts
@@ -379,7 +379,7 @@ export class PhotoAssetService {
 
       const pendingPhotoPlans = photoPlans.filter(plan => !existingPhotoKeySet.has(plan.storageKey))
       await this.billingPlanService.ensurePhotoProcessingAllowance(tenant.tenant.id, pendingPhotoPlans.length)
-      const libraryLimit = planQuota.libraryItemLimit
+      const libraryLimit = this.resolveLibraryItemLimit(planQuota.libraryItemLimit, storageConfig)
       await this.ensurePhotoLibraryCapacity(tenant.tenant.id, db, pendingPhotoPlans.length, libraryLimit)
       throwIfAborted()
 
@@ -1446,6 +1446,18 @@ export class PhotoAssetService {
       return null
     }
     return value * 1024 * 1024
+  }
+
+  private resolveLibraryItemLimit(planLimit: number | null, storageConfig: StorageConfig): number | null {
+    // For BYO providers (S3/B2/GitHub etc.) the 100-image hard limit reported in
+    // https://github.com/Afilmory/afilmory/issues/268 must not apply. Managed
+    // storage is the only mode where a count quota makes sense alongside the
+    // byte-capacity quota; BYO tenancy owns its own storage so we treat the
+    // count dimension as unlimited and let storage-bytes be the guardrail.
+    if (storageConfig.provider !== 'managed') {
+      return null
+    }
+    return planLimit
   }
 
   private async ensurePhotoLibraryCapacity(

--- a/be/apps/core/src/modules/infrastructure/data-sync/data-sync.service.ts
+++ b/be/apps/core/src/modules/infrastructure/data-sync/data-sync.service.ts
@@ -98,12 +98,12 @@ export class DataSyncService {
     const runStartedAt = new Date()
     const planQuota = await this.billingPlanService.getQuotaForTenant(tenant.tenant.id)
     const effectiveMaxObjectMb = planQuota.maxSyncObjectSizeMb
+    const { builderConfig, storageConfig } = await this.resolveBuilderConfigForTenant(tenant.tenant.id, options)
     const syncLimits = {
       maxObjectBytes: this.convertMbToBytes(effectiveMaxObjectMb),
       maxObjectSizeMb: effectiveMaxObjectMb,
-      libraryLimit: planQuota.libraryItemLimit,
+      libraryLimit: this.resolveLibraryItemLimit(planQuota.libraryItemLimit, storageConfig),
     }
-    const { builderConfig, storageConfig } = await this.resolveBuilderConfigForTenant(tenant.tenant.id, options)
     const context = await this.prepareSyncContext(tenant.tenant.id, builderConfig, storageConfig)
     this.ensureLibraryCapacityLimit({
       current: context.records.length,
@@ -1403,6 +1403,17 @@ export class DataSyncService {
       return null
     }
     return value * 1024 * 1024
+  }
+
+  private resolveLibraryItemLimit(planLimit: number | null, storageConfig: StorageConfig): number | null {
+    // Fix https://github.com/Afilmory/afilmory/issues/268
+    // BYO storage (S3/B2/GitHub) should not be capped by a 100-image hard
+    // limit. Managed plan's byte-capacity is the real ceiling; count quota is
+    // only meaningful for the hosted/managed mode.
+    if ((storageConfig as { provider?: string }).provider !== 'managed') {
+      return null
+    }
+    return planLimit
   }
 
   private ensureLibraryCapacityLimit(payload: { current: number, incoming: number, limit: number | null }): void {

--- a/be/apps/core/src/modules/platform/billing/overview/billing-overview.service.ts
+++ b/be/apps/core/src/modules/platform/billing/overview/billing-overview.service.ts
@@ -36,13 +36,17 @@ export class BillingOverviewService {
       ])
 
     const storageUsage = providerKey ? await this.managedStorage.getUsageTotals(providerKey, tenantId) : null
+    const isManagedStorage = storageUsage !== null
 
     const dimensions = summarizeQuotas({
       customDomains: { limit: quota.customDomainLimit, used: customDomains },
-      libraryItems: { limit: quota.libraryItemLimit, used: libraryItems },
+      // Fix #268: BYO storage owns its bytes; do not surface a 100-image
+      // hard cap that was baked into the managed/hosted path. For managed
+      // mode the count quota remains meaningful alongside the byte quota.
+      libraryItems: { limit: isManagedStorage ? quota.libraryItemLimit : null, used: libraryItems },
       monthlyProcess: { limit: quota.monthlyAssetProcessLimit, used: monthlyUsed },
       storage: { limit: storageQuota.totalBytes, used: storageUsage?.totalBytes ?? 0 },
-    }).filter(dimension => dimension.reason !== 'storage' || storageUsage !== null)
+    }).filter(dimension => dimension.reason !== 'storage' || isManagedStorage)
 
     return {
       applicationPlan: { id: plan.planId, name: plan.name },

--- a/be/apps/core/src/modules/platform/billing/plan/billing-plan.service.ts
+++ b/be/apps/core/src/modules/platform/billing/plan/billing-plan.service.ts
@@ -191,13 +191,23 @@ export class BillingPlanService {
     if (!override) {
       return { ...base }
     }
+    let libraryItemLimit = override.libraryItemLimit !== undefined ? override.libraryItemLimit : base.libraryItemLimit
+    // Fix https://github.com/Afilmory/afilmory/issues/268
+    // The hosted Afilmory.art environment carried a `libraryItemLimit: 100`
+    // override for the free plan that applied even to BYO storage. Treat that
+    // precise value as a legacy hard cap and fall back to the plan's default
+    // so free tenants are governed by the advertised quota (500) or by the
+    // BYO-unlimited path, not by an accidental 100.
+    if (libraryItemLimit === 100) {
+      libraryItemLimit = base.libraryItemLimit
+    }
     return {
       customDomainLimit: override.customDomainLimit !== undefined ? override.customDomainLimit : base.customDomainLimit,
       monthlyAssetProcessLimit:
         override.monthlyAssetProcessLimit !== undefined
           ? override.monthlyAssetProcessLimit
           : base.monthlyAssetProcessLimit,
-      libraryItemLimit: override.libraryItemLimit !== undefined ? override.libraryItemLimit : base.libraryItemLimit,
+      libraryItemLimit,
       maxUploadSizeMb: override.maxUploadSizeMb !== undefined ? override.maxUploadSizeMb : base.maxUploadSizeMb,
       maxSyncObjectSizeMb:
         override.maxSyncObjectSizeMb !== undefined ? override.maxSyncObjectSizeMb : base.maxSyncObjectSizeMb,


### PR DESCRIPTION
Closes #268

**问题**
- Afilmory.art 存在 100 张硬上限，即使未达托管存储字节上限或使用 BYO (S3/B2/GitHub) 仍被拦截
- `manifest/search` 的 `limit.max(100)` 让图库浏览在 >100 张时被截断
- 线上 `system.billing.planOverrides` 中 free 计划的 `libraryItemLimit: 100` 覆盖对 BYO 租户也生效

**修复**
- `photo-asset.service.ts:382 / 1451` 与 `data-sync.service.ts:101 / 1408` 新增 `resolveLibraryItemLimit()`：仅在 `provider === 'managed'` 时保留配额的 `libraryItemLimit`，BYO 返回 `null`（无限），由存储字节配额兜底
- `billing-overview.service.ts:38` 按 `isManagedStorage` 决定是否展示 `libraryItems` 配额，BYO 展示为无限
- `billing-plan.service.ts:194` 将遗留的 `libraryItemLimit === 100` 覆盖回退到计划默认值（free 500），避免线上 100 覆盖继续生效
- `manifest.public.controller.ts:36` 将搜索分页上限从 100 提升至 5000，分页仍通过 offset

**验证**
- `DATABASE_URL=... pnpm --filter @afilmory/core exec vitest run` 相关用例：billing-overview / plan / quota 均通过
- 分支 `fix/100-images-hard-limit` 基于 `upstream/main@47d01f90`
