### PR TITLE
feat(mobile,be): gallery communication notifications

### DIFF
--- a/.agents/skills/verifying-afilmory-apns/SKILL.md
+++ b/.agents/skills/verifying-afilmory-apns/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: verifying-afilmory-apns
+description: Use when verifying Afilmory gallery push notifications through local Core and an iOS Simulator, or when diagnosing missing banners, TopicDisallowed, POSIX 163 NSE launch failure, BadDeviceToken, APNs-disabled logs, text-only notifications, compact banners that still show the app icon instead of the gallery owner's avatar, or when Afilmory Local, simctl push, or unit tests are being treated as end-to-end proof.
+---
+
+# Verifying Afilmory APNs
+
+Prove this boundary:
+
+`local Core → APNs sandbox → iOS Simulator (app.afilmory) → NSE mutates content → banner, tap opens that gallery`
+
+Unit tests, Redis enqueue, an APNs 200, `simctl push`, or a fake-token `BadDeviceToken` are not completion.
+
+**Completion**
+
+- Core: no `TaskDropError` / `APNs request failed`; `apns_device` still `enabled=true` `environment=development`.
+- Visible Simulator banner (AX: `AFILMORY, …, <gallery name>, 刚刚发布了…` / `Just published…`).
+- Tap opens Explore on that gallery.
+- If `avatarUrl` / `imageUrl` were public HTTPS: NSE donates `INSendMessageIntent` with the **gallery owner's** avatar as `INPerson.image` (leading circle) and attaches the photo as `UNNotificationAttachment` (`ThumbnailHiddenKey` false). Do not put the published photo on the sender. SpringBoard should mutate content (`attachmentCount=1`, `Rendered avatar image: YES`). Compact proof on Simulator is owner avatar left, not the app icon, not the published photo. Long-press expansion must show the JPEG. iOS 26.5 Simulator compact banners have not rendered the trailing attachment thumb even without Communication enrichment — confirm trailing media on a physical device.
+
+Identify the run by `skill-proof-*` event ids. Start `pnpm --filter @afilmory/mobile native:memory-guard` before Simulator launch.
+
+## Hard stops
+
+- **Never use `Afilmory Local` / `app.afilmory.local` / `pnpm ios:local`.** No `aps-environment`; `supportsPushNotifications` is false.
+- **Never use the Release `Afilmory` scheme for local Core.** It talks to `api.afilmory.art` and reports APNs `production`.
+- **Never force `CODE_SIGN_IDENTITY=Apple Development` on Simulator, and never `AD_HOC_CODE_SIGNING_ALLOWED=NO`.** iOS 26.5 Simulator SDK requires ad hoc for the host; a Development-signed NSE beside an adhoc host dies with POSIX **163** (`Launchd job spawn failed` → `Did not mutate content`).
+- **Never print, commit, or persist `APNS_PRIVATE_KEY` / `.p8`.**
+- **Never truncate `apns_device` or `gallery_subscription`.**
+
+## Why the stock schemes fail
+
+| Scheme | Bundle | Debug? | Push | Local API override |
+|---|---|---|---|---|
+| `Afilmory Local` | `app.afilmory.local` | yes | no | yes |
+| `Afilmory` Release | `app.afilmory` | no | yes | no |
+
+Local Core + sandbox APNs needs Debug (Lab override + `APNsRegistrationEnvironment.development`) **and** production variant/bundle/entitlements. That mix is this skill's sandbox client, not a committed scheme.
+
+## Prerequisites
+
+- Booted Simulator (this skill's script defaults to **iPhone 17 Pro**), Xcode, AXe, `redis-cli`. Postgres is `afilmory_db` on `5432`; if `psql` is missing, `docker exec afilmory_db psql -U afilmory -d afilmory`. Probe Redis — it may be host `127.0.0.1:6379`, not a compose service named `afilmory_redis`.
+- Core on `127.0.0.1:1841` via `pnpm dev:be` with `APNS_TEAM_ID=KAMM5N88X3`, `APNS_KEY_ID=VUQAGR3F6U`, `APNS_BUNDLE_ID=app.afilmory`, `APNS_PRIVATE_KEY` from 1Password `op://Apple Developer/Afilmory APNs Sandbox`. Confirm by **absence** of `APNs delivery is disabled because provider credentials are not configured.` Never echo the key.
+- That key is **topic-specific**. The 1Password item name does not grant topic `app.afilmory`. In Apple Developer → Keys, the key must list `app.afilmory`. After adding a topic, **restart Core** — the HTTP/2 session can keep returning `TopicDisallowed`.
+- A fake token `BadDeviceToken` only proves request auth, not topic authorization.
+- Two local users: Simulator subscriber, publisher who owns a gallery the subscriber follows.
+
+## Simulator signing
+
+`scripts/build-sandbox-client.sh` **must `clean build`**. Incremental derived data can keep a cached Apple Development NSE next to a rebuilt adhoc host.
+
+After build, both `Afilmory.app` and `PlugIns/AfilmoryNotification.appex` must be `Signature=adhoc` / `TeamIdentifier=not set`. Yohaku Simulator apps are the same. Empty `codesign -d --entitlements :-` on the adhoc host is not a failure — check `Afilmory.app-Simulated.xcent` for `aps-environment=development` and `com.apple.developer.usernotifications.communication`.
+
+Do not post-sign the Simulator app with a Development identity; SpringBoard then denies launch.
+
+## Fast triage
+
+| Symptom | First check |
+|---|---|
+| No token / no iOS prompt | Built `Afilmory Local` |
+| Token registers, Core never queues | Core log `APNs delivery is disabled` |
+| `TopicDisallowed` | Key topics omit `app.afilmory`, or Core not restarted after a topic grant |
+| Queued, then POSIX 163 / `Did not mutate` | NSE not adhoc; `clean build` and reinstall |
+| Queued, device `enabled=false` | `BadDeviceToken`; sandbox client, not Release |
+| Compact banner still uses the app icon | NSE did not `updating(from: INSendMessageIntent)`; check communication entitlement, POSIX 163, and `avatarUrl` |
+| Compact leading circle is the published photo | NSE used `imageUrl` as `INPerson.image`; sender image must be `avatarUrl` (tenant owner `auth_user.image`) |
+| Banner, tap does nothing useful | Payload `route` / `gallerySlug` / `photoId`; NSE is unrelated |
+
+## Workflow
+
+1. **Inspect** branch, dirty files, booted UDID, Core port, Postgres/Redis mappings. Do not assume `5432`/`6379`/`1841`.
+2. **Start Core** with APNs vars. Disable warning must be absent. Hit `/api/health`, not `/api` (the latter can hang on static-web).
+3. **Build the sandbox client:** `bash .agents/skills/verifying-afilmory-apns/scripts/build-sandbox-client.sh`. Scheme `Afilmory Local` / Debug + `scripts/sandbox-client.xcconfig` → bundle `app.afilmory`, variant `production`. Refuse if installed bundle is `app.afilmory.local` or either binary is not adhoc.
+4. **Point it at local Core.** Launch `app.afilmory`. Open Developer Lab with `xcrun simctl openurl <udid> afilmory:///dev` (DEBUG) or Studio tab five times. Set **Local** (`http://localhost:1841`), Probe HTTP 200, sign in as the subscriber. Requests must hit `localhost:1841`, not `api.afilmory.art`.
+5. **Bind push.** Subscribe to the publisher's gallery. Accept the notification prompt. Require `PUT /push-devices` 200 and `apns_device` `enabled=true` `environment=development`. Do not print `device_token`. `simctl privacy grant notifications` is often `Operation not permitted` — use the in-app prompt.
+6. **Deliver.** Background to SpringBoard. Prefer a real Studio upload (`enqueueGalleryPublished`). Or `IMAGE_URL='https://…jpg' AVATAR_URL='https://…jpg' bash .agents/skills/verifying-afilmory-apns/scripts/enqueue-gallery-push.sh`. Use **distinct** HTTPS images so the leading owner avatar and trailing photo cannot be confused. HTTP URLs are dropped. Start `axe tap --label 'AFILMORY, 现在, <gallery>, 刚刚发布了 1 张新照片。' --wait-timeout 12` **before** enqueue so the banner is tappable; it dismisses in a few seconds. Labels include a relative time that changes (`现在` → `1分钟前`).
+7. **Proof.** Core `Task completed` without drop. Device still enabled. Banner AX. Compact banner: owner avatar left (camera badge if a photo was attached). Long-press expansion shows the JPEG. A trailing compact thumb is expected on device; iOS 26.5 Simulator has not shown one even for attachment-only notifications. Tap compact banner (not Notification Center swipe, which becomes a leading swipe-to-clear). `BadDeviceToken` on a stale row is not a failed run if the fresh Simulator row delivered.
+
+Invalid App Store profiles after App ID capability edits are unrelated; sandbox verification does not use them.
+
+## Failure guide
+
+| Symptom | Check |
+|---|---|
+| `supportsPushNotifications` never registers | Sandbox xcconfig not applied; still `app.afilmory.local` |
+| `APNs delivery is disabled` | Incomplete `APNS_*` in Core env |
+| `TopicDisallowed` | Keys UI topics; restart `pnpm dev:be` |
+| POSIX 163 / NSE never launches | Host vs NSE codesign mismatch; `clean build` |
+| `BadDeviceToken` then disabled | Release Production client, or stale token |
+| NSE launched, compact still shows app icon | Communication entitlement missing, `donate`/`updating(from:)` fell back, or no `avatarUrl` |
+| Compact left is the published photo | `INPerson.image` was built from `imageUrl`; it must be the owner `avatarUrl` |
+| Text-only and `Did not mutate` | NSE missing from the sandbox build, or spawn failed |
+| `imageUrl` / `avatarUrl` HTTP | rustfs HTTP is dropped; use public HTTPS |
+| Tap opens the wrong gallery | `gallerySlug` / deep link `photo` query |
+| Build script exits 141 | `grep -q` + `pipefail`; use `require_adhoc` as in the script |
+
+## Cleanup
+
+Stop only processes started for the run. Leave `afilmory_db` volumes and host Redis. Delete `apps/mobile/.derived-apns-sandbox` if created. Do not reset API environment on unrelated Simulator installs.
+
+## Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| "Local has no APNs, so skip Simulator" | Build the sandbox client. Local scheme is the wrong binary. |
+| "PushNotificationTests passed" | Payload/deep-link coverage, not APNs. |
+| "`simctl push` showed a banner" | Never leaves the Mac. Does not prove Core → APNs. |
+| "`ios:production` is the push app" | Release cannot retarget local Core; reports `production`. |
+| "Queued in Redis is enough" | Worker can drop or disable the device after that. |
+| "Fake token `BadDeviceToken` means the topic is allowed" | Auth only. Topic check can still be `TopicDisallowed`. |
+| "1Password item is named Afilmory APNs Sandbox" | Check the Key's topic list. This key is shared with Yohaku. |
+| "codesign entitlements dump is empty, so push is off" | Adhoc Simulator; read `*-Simulated.xcent`. |
+| "Force Apple Development so entitlements stick" | Mixed signing → POSIX 163. Stay adhoc on Simulator. |
+| "Compact banner has no trailing thumb, so NSE failed" | On iOS 26.5 Simulator, SpringBoard still reports `attachmentCount=1` and long-press shows the JPEG. Trailing compact thumbs have not rendered with or without Communication enrichment. Confirm on a physical device before changing NSE again. |
+| "Put the photo on the leading avatar so the compact banner has an image" | Wrong layout. Leading circle is the gallery user (`avatarUrl`). The published photo is the attachment, not `INPerson.image`. |
+| "Incremental build is enough after a signing experiment" | `clean build` or the cached Development NSE comes back. |

--- a/.agents/skills/verifying-afilmory-apns/scripts/build-sandbox-client.sh
+++ b/.agents/skills/verifying-afilmory-apns/scripts/build-sandbox-client.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+MOBILE="$ROOT/apps/mobile"
+XCCONFIG="$(cd "$(dirname "$0")" && pwd)/sandbox-client.xcconfig"
+DEVICE="${1:-iPhone 17 Pro}"
+DESTINATION="platform=iOS Simulator,name=${DEVICE}"
+
+cd "$MOBILE"
+pnpm native:generate
+
+xcodebuild -project Afilmory.xcodeproj \
+  -scheme 'Afilmory Local' \
+  -configuration Debug \
+  -xcconfig "$XCCONFIG" \
+  -destination "$DESTINATION" \
+  -derivedDataPath "$MOBILE/.derived-apns-sandbox" \
+  DEVELOPMENT_TEAM=KAMM5N88X3 \
+  clean build
+
+APP="$MOBILE/.derived-apns-sandbox/Build/Products/Debug-iphonesimulator/Afilmory.app"
+test -d "$APP"
+/usr/libexec/PlistBuddy -c 'Print :AfilmoryAppVariant' "$APP/Info.plist" | grep -qx production
+/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP/Info.plist" | grep -qx app.afilmory
+SIM_XCENT="$MOBILE/.derived-apns-sandbox/Build/Intermediates.noindex/Afilmory.build/Debug-iphonesimulator/Afilmory.build/Afilmory.app-Simulated.xcent"
+grep -q 'aps-environment' "$SIM_XCENT"
+
+require_adhoc() {
+  local output
+  output="$(codesign -dv --verbose=4 "$1" 2>&1 || true)"
+  [[ "$output" == *"Signature=adhoc"* ]]
+}
+# Incremental rebuild can leave a Development-signed NSE beside an adhoc host; SpringBoard then fails spawn with POSIX 163.
+require_adhoc "$APP"
+require_adhoc "$APP/PlugIns/AfilmoryNotification.appex"
+
+UDID="$(xcrun simctl list devices booted | grep -F "$DEVICE (" | grep -oE '[0-9A-F-]{36}' | head -1)"
+if [[ -z "$UDID" ]]; then
+  xcrun simctl boot "$DEVICE"
+  UDID="$(xcrun simctl list devices | grep -F "$DEVICE (" | grep -oE '[0-9A-F-]{36}' | head -1)"
+fi
+
+xcrun simctl install "$UDID" "$APP"
+printf 'Installed app.afilmory on %s (%s)\n' "$DEVICE" "$UDID"

--- a/.agents/skills/verifying-afilmory-apns/scripts/enqueue-gallery-push.sh
+++ b/.agents/skills/verifying-afilmory-apns/scripts/enqueue-gallery-push.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PGURL="${DATABASE_URL:-postgres://afilmory:afilmory@127.0.0.1:5432/afilmory}"
+REDIS_URL="${REDIS_URL:-redis://127.0.0.1:6379}"
+if [[ "$REDIS_URL" != redis://* ]]; then
+  REDIS_URL="redis://${REDIS_URL}"
+fi
+IMAGE_URL="${IMAGE_URL:-}"
+AVATAR_URL="${AVATAR_URL:-}"
+GALLERY_SLUG="${GALLERY_SLUG:-}"
+PHOTO_ID="${PHOTO_ID:-skill-proof}"
+WAIT_SECONDS="${WAIT_SECONDS:-8}"
+STREAM='queue:gallery-push-notifications:stream'
+
+psql_cmd() {
+  if command -v psql >/dev/null 2>&1; then
+    psql "$PGURL" -At -v ON_ERROR_STOP=1 "$@"
+  else
+    docker exec -i afilmory_db psql -U afilmory -d afilmory -At -v ON_ERROR_STOP=1 "$@"
+  fi
+}
+
+row="$(
+  psql_cmd -v gallery_slug="${GALLERY_SLUG}" <<'SQL'
+SELECT concat_ws(E'\t',
+  d.id,
+  t.id,
+  t.slug,
+  t.name)
+FROM apns_device d
+JOIN gallery_subscription s ON s.subscriber_user_id = d.user_id
+JOIN tenant t ON t.id = s.target_tenant_id
+WHERE d.enabled = true
+  AND t.status = 'active'
+  AND t.banned = false
+  AND (:'gallery_slug' = '' OR t.slug = :'gallery_slug')
+ORDER BY d.last_seen_at DESC
+LIMIT 1;
+SQL
+)"
+
+if [[ -z "$row" ]]; then
+  echo 'No enabled APNs device with a gallery subscription.' >&2
+  exit 1
+fi
+
+IFS=$'\t' read -r device_id tenant_id gallery_slug gallery_name <<<"$row"
+
+if [[ -z "$IMAGE_URL" ]]; then
+  IMAGE_URL="$(
+    psql_cmd -v tenant_id="$tenant_id" <<'SQL'
+SELECT manifest->'data'->>'thumbnailUrl'
+FROM photo_asset
+WHERE tenant_id = :'tenant_id'
+  AND manifest->'data'->>'thumbnailUrl' LIKE 'https://%'
+ORDER BY synced_at DESC
+LIMIT 1;
+SQL
+  )"
+  PHOTO_ID="$(
+    psql_cmd -v tenant_id="$tenant_id" <<'SQL'
+SELECT photo_id
+FROM photo_asset
+WHERE tenant_id = :'tenant_id'
+  AND manifest->'data'->>'thumbnailUrl' LIKE 'https://%'
+ORDER BY synced_at DESC
+LIMIT 1;
+SQL
+  )"
+fi
+
+if [[ -z "$AVATAR_URL" ]]; then
+  AVATAR_URL="$(
+    psql_cmd -v tenant_id="$tenant_id" <<'SQL'
+SELECT u.image
+FROM tenant_membership m
+JOIN auth_user u ON u.id = m.user_id
+WHERE m.tenant_id = :'tenant_id'
+  AND m.role = 'owner'
+  AND m.status = 'active'
+  AND u.image LIKE 'https://%'
+LIMIT 1;
+SQL
+  )"
+fi
+
+delivery_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+event_id="skill-proof-$(date +%s)"
+now_ms="$(python3 -c 'import time; print(int(time.time() * 1000))')"
+image_json='null'
+if [[ -n "${IMAGE_URL:-}" ]]; then
+  image_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$IMAGE_URL")"
+fi
+avatar_json='null'
+if [[ -n "${AVATAR_URL:-}" ]]; then
+  avatar_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$AVATAR_URL")"
+fi
+photo_json='null'
+if [[ -n "${PHOTO_ID:-}" ]]; then
+  photo_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$PHOTO_ID")"
+fi
+gallery_name_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$gallery_name")"
+gallery_slug_json="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$gallery_slug")"
+
+payload="$(
+  python3 - "$delivery_id" "$device_id" "$event_id" "$gallery_name_json" "$gallery_slug_json" "$image_json" "$avatar_json" "$photo_json" "$tenant_id" "$now_ms" <<'PY'
+import json, sys
+delivery_id, device_id, event_id, gallery_name, gallery_slug, image_url, avatar_url, photo_id, tenant_id, now_ms = sys.argv[1:]
+now = int(now_ms)
+body = {
+  "deliveryId": delivery_id,
+  "deviceId": device_id,
+  "eventId": event_id,
+  "galleryName": json.loads(gallery_name),
+  "gallerySlug": json.loads(gallery_slug),
+  "photoCount": 1,
+  "targetTenantId": tenant_id,
+}
+image = json.loads(image_url)
+avatar = json.loads(avatar_url)
+photo = json.loads(photo_id)
+if isinstance(image, str) and image:
+  body["imageUrl"] = image
+if isinstance(avatar, str) and avatar:
+  body["avatarUrl"] = avatar
+if isinstance(photo, str) and photo:
+  body["photoId"] = photo
+task = {
+  "id": delivery_id,
+  "name": "send-gallery-update",
+  "payload": body,
+  "attempts": 0,
+  "runAt": now,
+  "priority": 0,
+  "enqueueTime": now,
+}
+print(json.dumps(task, separators=(",", ":")))
+PY
+)"
+
+redis-cli -u "$REDIS_URL" XADD "$STREAM" '*' payload "$payload" >/dev/null
+
+echo "Queued eventId=$event_id deviceId=$device_id gallery=$gallery_slug"
+if [[ -z "${AVATAR_URL:-}" ]]; then
+  echo 'No https owner avatar; compact leading circle will not be the gallery user.'
+fi
+if [[ -z "${IMAGE_URL:-}" ]]; then
+  echo 'No https thumbnail; compact trailing image will be missing.'
+fi
+
+echo "Waiting ${WAIT_SECONDS}s for Core worker…"
+sleep "$WAIT_SECONDS"
+
+psql_cmd -v device_id="$device_id" <<'SQL'
+SELECT concat('device enabled=', enabled, ' environment=', environment)
+FROM apns_device
+WHERE id = :'device_id';
+SQL
+
+echo "Evidence ID: $event_id"

--- a/.agents/skills/verifying-afilmory-apns/scripts/sandbox-client.xcconfig
+++ b/.agents/skills/verifying-afilmory-apns/scripts/sandbox-client.xcconfig
@@ -1,0 +1,18 @@
+AFILMORY_APP_VARIANT = production
+AFILMORY_API_ENVIRONMENT = local
+AFILMORY_DISPLAY_NAME = Afilmory
+AFILMORY_URL_SCHEME = afilmory
+AFILMORY_APP_GROUP_IDENTIFIER = group.app.afilmory
+
+BUNDLE_ID_Afilmory = app.afilmory
+BUNDLE_ID_AfilmoryNotification = app.afilmory.notification
+BUNDLE_ID_AfilmoryShare = app.afilmory.share
+BUNDLE_ID_AfilmoryWidgets = app.afilmory.widgets
+BUNDLE_ID_AfilmoryTests = app.afilmory.tests
+PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_ID_$(TARGET_NAME))
+
+ENTITLEMENTS_Afilmory = Afilmory/Afilmory.entitlements
+ENTITLEMENTS_AfilmoryNotification = targets/notification/AfilmoryNotification.entitlements
+ENTITLEMENTS_AfilmoryShare = targets/share/AfilmoryShare.entitlements
+ENTITLEMENTS_AfilmoryWidgets = targets/widgets/AfilmoryWidgets.entitlements
+CODE_SIGN_ENTITLEMENTS = $(ENTITLEMENTS_$(TARGET_NAME))

--- a/.github/workflows/mobile-testflight.yml
+++ b/.github/workflows/mobile-testflight.yml
@@ -42,6 +42,7 @@ jobs:
           APP_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROFILE }}
           SHARE_PROFILE_BASE64: ${{ secrets.IOS_SHARE_APPSTORE_PROFILE }}
           WIDGETS_PROFILE_BASE64: ${{ secrets.IOS_WIDGETS_APPSTORE_PROFILE }}
+          NOTIFICATION_PROFILE_BASE64: ${{ secrets.IOS_NOTIFICATION_APPSTORE_PROFILE }}
         run: bash scripts/import-ci-signing-assets.sh
 
       - name: Configure manual signing
@@ -113,6 +114,7 @@ jobs:
               <key>app.afilmory</key><string>$IOS_APP_PROFILE_NAME</string>
               <key>app.afilmory.share</key><string>$IOS_SHARE_PROFILE_NAME</string>
               <key>app.afilmory.widgets</key><string>$IOS_WIDGETS_PROFILE_NAME</string>
+              <key>app.afilmory.notification</key><string>$IOS_NOTIFICATION_PROFILE_NAME</string>
             </dict>
             <key>manageAppVersionAndBuildNumber</key><true/>
           </dict>
@@ -131,7 +133,7 @@ jobs:
         run: |
           security delete-keychain "$RUNNER_TEMP/ci.keychain-db" || true
           rm -f "$RUNNER_TEMP/dist.p12" "$RUNNER_TEMP"/AuthKey_*.p8
-          for profile_uuid in "$IOS_APP_PROFILE_UUID" "$IOS_SHARE_PROFILE_UUID" "$IOS_WIDGETS_PROFILE_UUID"; do
+          for profile_uuid in "$IOS_APP_PROFILE_UUID" "$IOS_SHARE_PROFILE_UUID" "$IOS_WIDGETS_PROFILE_UUID" "$IOS_NOTIFICATION_PROFILE_UUID"; do
             if [[ "$profile_uuid" =~ ^[0-9A-Fa-f-]{36}$ ]]; then
               rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
               rm -f "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles/$profile_uuid.mobileprovision"

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -38,3 +38,6 @@ yarn-error.*
 /ios
 /android
 /Afilmory/Resources/Locales/
+
+# APNs sandbox verification derived data
+.derived-apns-sandbox/

--- a/apps/mobile/Afilmory.xcodeproj/project.pbxproj
+++ b/apps/mobile/Afilmory.xcodeproj/project.pbxproj
@@ -8,11 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		0036AB47AA345AEDC151E854 /* google-g.png in Resources */ = {isa = PBXBuildFile; fileRef = 25B5393D7A1A38FF74141B1C /* google-g.png */; };
+		1C5D38C777EAB742DA92A47E /* GalleryPushImageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F79DDD6CE6213A680D3B3093 /* GalleryPushImageAttachment.swift */; };
+		5E204357F276F92B477326DF /* GalleryPushCommunication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAD9D0EF35936D19B1691E1 /* GalleryPushCommunication.swift */; };
 		76D823DDC359CAF2BDCEEA32 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 6AF472CC061F0A538031C03B /* GRDB */; };
 		8AF800F517A9D7C64EAE699A /* AfilmoryLocal.icon in Resources */ = {isa = PBXBuildFile; fileRef = 3983EB8B2EFD494138D3C9C5 /* AfilmoryLocal.icon */; };
 		AF274338BBFF344A7BAEBFE9 /* Afilmory.icon in Resources */ = {isa = PBXBuildFile; fileRef = 2B40A13E3BF517C4D52948AA /* Afilmory.icon */; };
 		C1A991BD5A56277D4221B474 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = 13DF510201D12CE06D3CE37B /* SDWebImage */; };
 		C363A8EC4AC4B02E9EF816AF /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B790B374D13B20C390F53E /* WidgetSnapshot.swift */; };
+		D69FA277A4EB1BA671FCF76B /* Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D205E83D76679EEFDEAFCF79 /* Intents.framework */; };
+		E94E60AB2D0A3A2A0A1A8362 /* AfilmoryNotification.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A900A86121037AFE9773DBDF /* AfilmoryNotification.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		ECF656AA24646E37091A813F /* AfilmoryShare.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7D17294B38A9991D586FCEA0 /* AfilmoryShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EF187F8AE4575B5B50FBC76A /* AfilmoryWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A3E83850A95108CE09366C23 /* AfilmoryWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -32,6 +36,13 @@
 			remoteGlobalIDString = 49FCC468078AAEFC1B5AA196;
 			remoteInfo = Afilmory;
 		};
+		5A70247A07DC7CF31D5CA23A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E3FF1388E7806E07493CD991 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8C8591ADA4B3ACD6020325F9;
+			remoteInfo = AfilmoryNotification;
+		};
 		705AD7B2843D3DE13373B4EE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E3FF1388E7806E07493CD991 /* Project object */;
@@ -50,6 +61,7 @@
 			files = (
 				ECF656AA24646E37091A813F /* AfilmoryShare.appex in Embed Foundation Extensions */,
 				EF187F8AE4575B5B50FBC76A /* AfilmoryWidgets.appex in Embed Foundation Extensions */,
+				E94E60AB2D0A3A2A0A1A8362 /* AfilmoryNotification.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -57,17 +69,28 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0BAD9D0EF35936D19B1691E1 /* GalleryPushCommunication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryPushCommunication.swift; sourceTree = "<group>"; };
 		25B5393D7A1A38FF74141B1C /* google-g.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "google-g.png"; sourceTree = "<group>"; };
 		2B40A13E3BF517C4D52948AA /* Afilmory.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = Afilmory.icon; sourceTree = "<group>"; };
 		3983EB8B2EFD494138D3C9C5 /* AfilmoryLocal.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AfilmoryLocal.icon; sourceTree = "<group>"; };
 		7D17294B38A9991D586FCEA0 /* AfilmoryShare.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = AfilmoryShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		93B790B374D13B20C390F53E /* WidgetSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshot.swift; sourceTree = "<group>"; };
 		A3E83850A95108CE09366C23 /* AfilmoryWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = AfilmoryWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A900A86121037AFE9773DBDF /* AfilmoryNotification.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = AfilmoryNotification.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		D205E83D76679EEFDEAFCF79 /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		E5ADC356FDCD915A2B141CB0 /* AfilmoryTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AfilmoryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7C24D2808A5C15D8643768F /* Afilmory.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Afilmory.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F79DDD6CE6213A680D3B3093 /* GalleryPushImageAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryPushImageAttachment.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		12283EAD29279421E3B5938D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 8C8591ADA4B3ACD6020325F9 /* AfilmoryNotification */;
+		};
 		BBB023149912B5D758089AD3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -137,9 +160,29 @@
 			path = targets/widgets;
 			sourceTree = "<group>";
 		};
+		BECBC75D21472EF02A7ECB14 /* targets/notification */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				12283EAD29279421E3B5938D /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = targets/notification;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		34BA265DC83CD4D7FBE42094 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D69FA277A4EB1BA671FCF76B /* Intents.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C917EBF8F91D5CBCE842C420 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -152,6 +195,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E12E619DF00F0AACBD7B062 /* Push */ = {
+			isa = PBXGroup;
+			children = (
+				0BAD9D0EF35936D19B1691E1 /* GalleryPushCommunication.swift */,
+				F79DDD6CE6213A680D3B3093 /* GalleryPushImageAttachment.swift */,
+			);
+			path = Push;
+			sourceTree = "<group>";
+		};
 		6F0AADD47B0E75021D267508 /* Widgets */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,6 +215,7 @@
 		75721C460ECAD410BBA1BC86 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				0E12E619DF00F0AACBD7B062 /* Push */,
 				6F0AADD47B0E75021D267508 /* Widgets */,
 			);
 			path = Core;
@@ -171,13 +224,15 @@
 		A3AF475FD4E25C2AC4658B92 = {
 			isa = PBXGroup;
 			children = (
-				2241A14B486857EDFAA4D436 /* Afilmory */,
 				D0539BCC111E5D10BFA9A46E /* Afilmory */,
+				2241A14B486857EDFAA4D436 /* Afilmory */,
 				F7E1D90B31803524C6BD87AC /* icons */,
 				CC890C61115C8862C1BE9EB2 /* images */,
+				BECBC75D21472EF02A7ECB14 /* targets/notification */,
 				363C0633498AD7FB6A29DB76 /* targets/share */,
 				87E41E18BDAE2D40961A3359 /* targets/widgets */,
 				575F7F6CF19B796A338D29A5 /* Tests */,
+				CC2504C5C860BC194E664ACD /* Frameworks */,
 				B0A5F813E326BDDE0F59B032 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -186,11 +241,20 @@
 			isa = PBXGroup;
 			children = (
 				E7C24D2808A5C15D8643768F /* Afilmory.app */,
+				A900A86121037AFE9773DBDF /* AfilmoryNotification.appex */,
 				7D17294B38A9991D586FCEA0 /* AfilmoryShare.appex */,
 				E5ADC356FDCD915A2B141CB0 /* AfilmoryTests.xctest */,
 				A3E83850A95108CE09366C23 /* AfilmoryWidgets.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		CC2504C5C860BC194E664ACD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D205E83D76679EEFDEAFCF79 /* Intents.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		CC890C61115C8862C1BE9EB2 /* images */ = {
@@ -280,6 +344,7 @@
 			dependencies = (
 				ABD3C7E27F0F01CC57B0CA1F /* PBXTargetDependency */,
 				704E52E79B0FB771488F8088 /* PBXTargetDependency */,
+				EF80FDCFFE8F24A6DD6A49AA /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				2241A14B486857EDFAA4D436 /* Afilmory */,
@@ -292,6 +357,28 @@
 			productName = Afilmory;
 			productReference = E7C24D2808A5C15D8643768F /* Afilmory.app */;
 			productType = "com.apple.product-type.application";
+		};
+		8C8591ADA4B3ACD6020325F9 /* AfilmoryNotification */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F6953E112FA58DA690DBB733 /* Build configuration list for PBXNativeTarget "AfilmoryNotification" */;
+			buildPhases = (
+				5DF63A30C60096E22609E5B2 /* Sources */,
+				BE1F05CA99B65FCF49BA2BE5 /* Resources */,
+				34BA265DC83CD4D7FBE42094 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				BECBC75D21472EF02A7ECB14 /* targets/notification */,
+			);
+			name = AfilmoryNotification;
+			packageProductDependencies = (
+			);
+			productName = AfilmoryNotification;
+			productReference = A900A86121037AFE9773DBDF /* AfilmoryNotification.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		EED569562E5B8E4DD3F3C7F1 /* AfilmoryWidgets */ = {
 			isa = PBXNativeTarget;
@@ -332,6 +419,9 @@
 					49FCC468078AAEFC1B5AA196 = {
 						DevelopmentTeam = KAMM5N88X3;
 					};
+					8C8591ADA4B3ACD6020325F9 = {
+						DevelopmentTeam = KAMM5N88X3;
+					};
 					EED569562E5B8E4DD3F3C7F1 = {
 						DevelopmentTeam = KAMM5N88X3;
 					};
@@ -356,6 +446,7 @@
 			projectRoot = "";
 			targets = (
 				49FCC468078AAEFC1B5AA196 /* Afilmory */,
+				8C8591ADA4B3ACD6020325F9 /* AfilmoryNotification */,
 				355117DF7EBA74FB8E2A3F01 /* AfilmoryShare */,
 				418883D2F6760B61427AFE0B /* AfilmoryTests */,
 				EED569562E5B8E4DD3F3C7F1 /* AfilmoryWidgets */,
@@ -395,6 +486,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE1F05CA99B65FCF49BA2BE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -402,6 +500,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5DF63A30C60096E22609E5B2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E204357F276F92B477326DF /* GalleryPushCommunication.swift in Sources */,
+				1C5D38C777EAB742DA92A47E /* GalleryPushImageAttachment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -445,9 +552,36 @@
 			target = 355117DF7EBA74FB8E2A3F01 /* AfilmoryShare */;
 			targetProxy = 10F636B930F4BE69904B4BE3 /* PBXContainerItemProxy */;
 		};
+		EF80FDCFFE8F24A6DD6A49AA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8C8591ADA4B3ACD6020325F9 /* AfilmoryNotification */;
+			targetProxy = 5A70247A07DC7CF31D5CA23A /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0955F03199FE1274ED3A82AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = targets/notification/AfilmoryNotification.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = targets/notification/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.4;
+				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.notification;
+				PRODUCT_MODULE_NAME = AfilmoryNotification;
+				PRODUCT_NAME = AfilmoryNotification;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		257B8361321DF15339A535B2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -509,6 +643,27 @@
 			};
 			name = Release;
 		};
+		313782784C8A0898255949FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = targets/notification/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.4;
+				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.local.notification;
+				PRODUCT_MODULE_NAME = AfilmoryNotification;
+				PRODUCT_NAME = AfilmoryNotification;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		3A909547F2A3F2E07C58FF03 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -521,7 +676,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.share;
 				PRODUCT_MODULE_NAME = AfilmoryShare;
 				PRODUCT_NAME = AfilmoryShare;
@@ -569,7 +724,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.local;
 				PRODUCT_MODULE_NAME = Afilmory;
 				PRODUCT_NAME = Afilmory;
@@ -592,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.widgets;
 				PRODUCT_MODULE_NAME = AfilmoryWidgets;
 				PRODUCT_NAME = AfilmoryWidgets;
@@ -614,7 +769,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.local.share;
 				PRODUCT_MODULE_NAME = AfilmoryShare;
 				PRODUCT_NAME = AfilmoryShare;
@@ -636,7 +791,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory.local.widgets;
 				PRODUCT_MODULE_NAME = AfilmoryWidgets;
 				PRODUCT_NAME = AfilmoryWidgets;
@@ -665,7 +820,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = app.afilmory;
 				PRODUCT_MODULE_NAME = Afilmory;
 				PRODUCT_NAME = Afilmory;
@@ -797,6 +952,15 @@
 			buildConfigurations = (
 				A68A51A62CF86FBA9B8C1F78 /* Debug */,
 				3A909547F2A3F2E07C58FF03 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F6953E112FA58DA690DBB733 /* Build configuration list for PBXNativeTarget "AfilmoryNotification" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				313782784C8A0898255949FF /* Debug */,
+				0955F03199FE1274ED3A82AD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/apps/mobile/Afilmory/Afilmory.entitlements
+++ b/apps/mobile/Afilmory/Afilmory.entitlements
@@ -4,6 +4,8 @@
 <dict>
   <key>aps-environment</key>
   <string>development</string>
+  <key>com.apple.developer.usernotifications.communication</key>
+  <true/>
   <key>com.apple.developer.associated-domains</key>
   <array>
     <string>applinks:afilmory.art</string>

--- a/apps/mobile/Afilmory/App/GalleryRouteRequest.swift
+++ b/apps/mobile/Afilmory/App/GalleryRouteRequest.swift
@@ -113,7 +113,8 @@ enum AfilmoryDeepLink: Equatable, Sendable {
     return GalleryRouteRequest(
       requestId: query["event"]?.trimmingToNil ?? "route:\(slug)",
       slug: slug,
-      title: query["name"]?.trimmingToNil ?? slug
+      title: query["name"]?.trimmingToNil ?? slug,
+      photoID: query["photo"]?.trimmingToNil
     )
   }
 }
@@ -129,11 +130,16 @@ func galleryNotificationDeepLink(
 
   let galleryName = (userInfo["galleryName"] as? String)?.trimmingToNil ?? slug
   let eventId = (userInfo["eventId"] as? String)?.trimmingToNil ?? UUID().uuidString
+  let photoId = (userInfo["photoId"] as? String)?.trimmingToNil
   guard var components = URLComponents(string: "\(scheme):///explore") else { return nil }
-  components.queryItems = [
+  var queryItems = [
     URLQueryItem(name: "gallery", value: slug),
     URLQueryItem(name: "name", value: galleryName),
     URLQueryItem(name: "event", value: eventId),
   ]
+  if let photoId {
+    queryItems.append(URLQueryItem(name: "photo", value: photoId))
+  }
+  components.queryItems = queryItems
   return components.url
 }

--- a/apps/mobile/Afilmory/Core/Push/APNsRegistrationCoordinator.swift
+++ b/apps/mobile/Afilmory/Core/Push/APNsRegistrationCoordinator.swift
@@ -54,6 +54,14 @@ final class APNsRegistrationCoordinator {
     guard AfilmoryBuildConfiguration.supportsPushNotifications else { return }
     guard !started else { return }
     started = true
+    UNUserNotificationCenter.current().setNotificationCategories([
+      UNNotificationCategory(
+        identifier: GalleryPushCommunication.categoryIdentifier,
+        actions: [],
+        intentIdentifiers: ["INSendMessageIntent"],
+        options: []
+      ),
+    ])
     sessionObservation = AfilmorySessionStore.shared.observe { [weak self] state in
       Task { @MainActor in
         self?.handleSessionState(state)

--- a/apps/mobile/Afilmory/Core/Push/GalleryPushCommunication.swift
+++ b/apps/mobile/Afilmory/Core/Push/GalleryPushCommunication.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Intents
+import os
+import UserNotifications
+
+enum GalleryPushCommunication {
+  static let categoryIdentifier = "GALLERY_UPDATE"
+  static let serviceName = "Afilmory"
+  private static let log = Logger(subsystem: "app.afilmory.notification", category: "GalleryPush")
+
+  static func galleryIdentity(from userInfo: [AnyHashable: Any]) -> (name: String, slug: String)? {
+    guard let slug = trimmed(userInfo["gallerySlug"]), !slug.isEmpty else {
+      return nil
+    }
+    let name = trimmed(userInfo["galleryName"])
+    return (name?.isEmpty == false ? name! : slug, slug)
+  }
+
+  static func makeSendMessageIntent(
+    galleryName: String,
+    gallerySlug: String,
+    body: String,
+    avatarData: Data?
+  ) -> INSendMessageIntent {
+    let handle = INPersonHandle(value: gallerySlug, type: .unknown)
+    let sender = INPerson(
+      personHandle: handle,
+      nameComponents: nil,
+      displayName: galleryName,
+      image: avatarData.map(INImage.init(imageData:)),
+      contactIdentifier: nil,
+      customIdentifier: gallerySlug,
+      isMe: false,
+      suggestionType: .none
+    )
+    return INSendMessageIntent(
+      recipients: nil,
+      outgoingMessageType: .outgoingMessageText,
+      content: body,
+      speakableGroupName: nil,
+      conversationIdentifier: gallerySlug,
+      serviceName: serviceName,
+      sender: sender,
+      attachments: nil
+    )
+  }
+
+  static func donateAndUpdate(
+    _ content: UNMutableNotificationContent,
+    galleryName: String,
+    gallerySlug: String,
+    avatarData: Data?,
+    completion: @escaping (UNNotificationContent) -> Void
+  ) {
+    content.categoryIdentifier = categoryIdentifier
+    logAttachments("BEFORE UPDATE", content.attachments)
+    let intent = makeSendMessageIntent(
+      galleryName: galleryName,
+      gallerySlug: gallerySlug,
+      body: content.body,
+      avatarData: avatarData
+    )
+    let interaction = INInteraction(intent: intent, response: nil)
+    interaction.direction = .incoming
+    interaction.donate { error in
+      guard error == nil else {
+        completion(content)
+        return
+      }
+      do {
+        let updated = try content.updating(from: intent)
+        logAttachments("AFTER UPDATE", updated.attachments)
+        if updated.attachments.isEmpty, !content.attachments.isEmpty,
+           let restored = updated.mutableCopy() as? UNMutableNotificationContent
+        {
+          restored.attachments = content.attachments
+          logAttachments("RESTORED", restored.attachments)
+          completion(restored)
+          return
+        }
+        completion(updated)
+      } catch {
+        completion(content)
+      }
+    }
+  }
+
+  private static func logAttachments(_ label: String, _ attachments: [UNNotificationAttachment]) {
+    log.info("\(label, privacy: .public) count=\(attachments.count, privacy: .public)")
+    for attachment in attachments {
+      log.info(
+        "\(label, privacy: .public) id=\(attachment.identifier, privacy: .public) type=\(attachment.type, privacy: .public) path=\(attachment.url.lastPathComponent, privacy: .public)"
+      )
+    }
+  }
+
+  private static func trimmed(_ value: Any?) -> String? {
+    (value as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/apps/mobile/Afilmory/Core/Push/GalleryPushImageAttachment.swift
+++ b/apps/mobile/Afilmory/Core/Push/GalleryPushImageAttachment.swift
@@ -1,0 +1,46 @@
+import Foundation
+import UserNotifications
+
+enum GalleryPushImageAttachmentError: Error {
+  case invalidData
+}
+
+enum GalleryPushImageAttachment {
+  private static let maxByteCount = 5 * 1024 * 1024
+
+  static func remoteImageURL(from userInfo: [AnyHashable: Any]) -> URL? {
+    remoteURL(from: userInfo, key: "imageUrl")
+  }
+
+  static func remoteAvatarURL(from userInfo: [AnyHashable: Any]) -> URL? {
+    remoteURL(from: userInfo, key: "avatarUrl")
+  }
+
+  private static func remoteURL(from userInfo: [AnyHashable: Any], key: String) -> URL? {
+    guard let raw = userInfo[key] as? String else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let url = URL(string: trimmed),
+          url.scheme?.lowercased() == "https",
+          let host = url.host,
+          !host.isEmpty
+    else { return nil }
+    return url
+  }
+
+  static func makeAttachment(from data: Data) throws -> UNNotificationAttachment {
+    guard !data.isEmpty, data.count <= maxByteCount else {
+      throw GalleryPushImageAttachmentError.invalidData
+    }
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let filename = data.starts(with: [0xFF, 0xD8, 0xFF]) ? "photo.jpg" : "photo.png"
+    let fileURL = directory.appending(path: filename)
+    try data.write(to: fileURL, options: .atomic)
+    return try UNNotificationAttachment(
+      identifier: "photo",
+      url: fileURL,
+      options: [UNNotificationAttachmentOptionsThumbnailHiddenKey: false]
+    )
+  }
+}

--- a/apps/mobile/Afilmory/Info.plist
+++ b/apps/mobile/Afilmory/Info.plist
@@ -77,6 +77,10 @@
 	<string>Allow Afilmory Studio to select photos for your gallery.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -60,7 +60,7 @@ Everything app-side lives under a single `Afilmory/` root (the old `NativeApp` +
 - `Afilmory/DesignSystem/` — `AdaptiveGlass`, `NativeControls`, `LiquidGlassSegmentedControl`, shared UIKit extensions, and `Transition/` (photo transition animators).
 - `Afilmory/Resources/` — String Catalogs, asset catalogs.
 - `Tests/` — the `AfilmoryTests` unit-test bundle (plus `Tests/Fixtures/`).
-- `targets/share/` and `targets/widgets/` — separate app-extension targets. They do **not** see app-target code; the share extension re-declares its own `group.app.afilmory` constant and its own String Catalog.
+- `targets/share/`, `targets/widgets/`, and `targets/notification/` — separate app-extension targets. They do **not** see app-target code; the share extension re-declares its own `group.app.afilmory` constant and its own String Catalog. The notification service compiles `Afilmory/Core/Push/GalleryPushImageAttachment.swift` into its own module.
 
 ## Runtime architecture
 

--- a/apps/mobile/RELEASE.md
+++ b/apps/mobile/RELEASE.md
@@ -24,7 +24,14 @@ Run `pnpm --filter @afilmory/mobile native:test` for the Swift behavior suite.
 ### Apple Developer portal ([developer.apple.com](https://developer.apple.com/account))
 
 1. **Identifiers → +** — register App ID `app.afilmory` (explicit) and enable
-   **Sign in with Apple** and **Push Notifications**.
+   **Sign in with Apple**, **Push Notifications**, and **Communication
+   Notifications**. Also register `app.afilmory.notification` for the
+   Notification Service Extension and enable **Communication Notifications** on
+   it (Developer portal / Xcode; the public App Store Connect capability enum
+   does not include this type). Create an App Store distribution profile for
+   that App ID and store it as `IOS_NOTIFICATION_APPSTORE_PROFILE`. CI automatic
+   signing (`-allowProvisioningUpdates`) should attach the capability when the
+   entitlement is present.
 2. **Certificates** — create an **Apple Distribution** certificate. Easiest via Xcode:
    Settings → Accounts → team → Manage Certificates → + → Apple Distribution.
    Then export it from Keychain Access as `.p12` with a password.
@@ -83,6 +90,7 @@ submitting a build:
 | `ASC_KEY_ID` | API key ID |
 | `ASC_ISSUER_ID` | API key issuer ID |
 | `ASC_API_KEY_P8` | raw contents of the `.p8` file |
+| `IOS_NOTIFICATION_APPSTORE_PROFILE` | base64 of the `app.afilmory.notification` App Store profile |
 
 ### First submission only
 

--- a/apps/mobile/RELEASE.md
+++ b/apps/mobile/RELEASE.md
@@ -28,10 +28,10 @@ Run `pnpm --filter @afilmory/mobile native:test` for the Swift behavior suite.
    Notifications**. Also register `app.afilmory.notification` for the
    Notification Service Extension and enable **Communication Notifications** on
    it (Developer portal / Xcode; the public App Store Connect capability enum
-   does not include this type). Create an App Store distribution profile for
-   that App ID and store it as `IOS_NOTIFICATION_APPSTORE_PROFILE`. CI automatic
-   signing (`-allowProvisioningUpdates`) should attach the capability when the
-   entitlement is present.
+   does not include this type). After the capability is on both App IDs, recreate
+   App Store profiles and store them as `IOS_APPSTORE_PROFILE` and
+   `IOS_NOTIFICATION_APPSTORE_PROFILE`. CI import asserts
+   `com.apple.developer.usernotifications.communication` on both.
 2. **Certificates** — create an **Apple Distribution** certificate. Easiest via Xcode:
    Settings → Accounts → team → Manage Certificates → + → Apple Distribution.
    Then export it from Keychain Access as `.p12` with a password.
@@ -90,7 +90,7 @@ submitting a build:
 | `ASC_KEY_ID` | API key ID |
 | `ASC_ISSUER_ID` | API key issuer ID |
 | `ASC_API_KEY_P8` | raw contents of the `.p8` file |
-| `IOS_NOTIFICATION_APPSTORE_PROFILE` | base64 of the `app.afilmory.notification` App Store profile |
+| `IOS_NOTIFICATION_APPSTORE_PROFILE` | base64 of the `app.afilmory.notification` App Store profile (must include Communication Notifications) |
 
 ### First submission only
 

--- a/apps/mobile/Tests/PushNotificationTests.swift
+++ b/apps/mobile/Tests/PushNotificationTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Intents
+import UIKit
 import XCTest
 
 @testable import Afilmory
@@ -29,6 +31,117 @@ final class PushNotificationTests: XCTestCase {
     XCTAssertEqual(query["gallery"], "street-photo")
     XCTAssertEqual(query["name"], "Street Photo")
     XCTAssertEqual(query["event"], "event-123")
+    XCTAssertNil(query["photo"])
+  }
+
+  func testGalleryNotificationDeepLinkFocusesThePreviewPhoto() throws {
+    let url = try XCTUnwrap(
+      galleryNotificationDeepLink(
+        userInfo: [
+          "route": "gallery",
+          "gallerySlug": "street-photo",
+          "galleryName": "Street Photo",
+          "eventId": "event-123",
+          "photoId": "DSC_7132",
+          "imageUrl": "https://cdn.example/t.jpg",
+        ],
+        scheme: "afilmory-local"
+      )
+    )
+    let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+      item.value.map { (item.name, $0) }
+    })
+
+    XCTAssertEqual(query["photo"], "DSC_7132")
+    XCTAssertEqual(
+      AfilmoryDeepLink.parse(url, customScheme: "afilmory-local"),
+      .explore(
+        GalleryRouteRequest(
+          requestId: "event-123",
+          slug: "street-photo",
+          title: "Street Photo",
+          photoID: "DSC_7132"
+        )
+      )
+    )
+  }
+
+  func testGalleryPushImageURLRequiresHttps() {
+    XCTAssertEqual(
+      GalleryPushImageAttachment.remoteImageURL(from: ["imageUrl": "https://cdn.example/t.jpg"])?.absoluteString,
+      "https://cdn.example/t.jpg"
+    )
+    XCTAssertNil(GalleryPushImageAttachment.remoteImageURL(from: ["imageUrl": "http://cdn.example/t.jpg"]))
+    XCTAssertNil(GalleryPushImageAttachment.remoteImageURL(from: ["imageUrl": "/thumbnails/t.jpg"]))
+    XCTAssertNil(GalleryPushImageAttachment.remoteImageURL(from: [:]))
+    XCTAssertNil(
+      GalleryPushImageAttachment.remoteImageURL(from: ["avatarUrl": "https://cdn.example/me.jpg"])
+    )
+  }
+
+  func testGalleryPushAvatarURLRequiresHttps() {
+    XCTAssertEqual(
+      GalleryPushImageAttachment.remoteAvatarURL(from: ["avatarUrl": "https://cdn.example/me.jpg"])?.absoluteString,
+      "https://cdn.example/me.jpg"
+    )
+    XCTAssertNil(GalleryPushImageAttachment.remoteAvatarURL(from: ["avatarUrl": "http://cdn.example/me.jpg"]))
+    XCTAssertNil(
+      GalleryPushImageAttachment.remoteAvatarURL(from: ["imageUrl": "https://cdn.example/t.jpg"])
+    )
+  }
+
+  func testGalleryPushImageAttachmentWritesAJpegPreview() throws {
+    let jpeg = try XCTUnwrap(
+      UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).image { _ in }.jpegData(compressionQuality: 0.9)
+    )
+    let attachment = try GalleryPushImageAttachment.makeAttachment(from: jpeg)
+    XCTAssertEqual(attachment.identifier, "photo")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: attachment.url.path))
+  }
+
+  func testGalleryPushCommunicationReadsGalleryIdentity() {
+    XCTAssertEqual(
+      GalleryPushCommunication.galleryIdentity(
+        from: ["gallerySlug": "street-photo", "galleryName": "Street Photo"]
+      )?.slug,
+      "street-photo"
+    )
+    XCTAssertEqual(
+      GalleryPushCommunication.galleryIdentity(
+        from: ["gallerySlug": "street-photo", "galleryName": "Street Photo"]
+      )?.name,
+      "Street Photo"
+    )
+    XCTAssertEqual(
+      GalleryPushCommunication.galleryIdentity(from: ["gallerySlug": "street-photo"])?.name,
+      "street-photo"
+    )
+    XCTAssertNil(GalleryPushCommunication.galleryIdentity(from: [:]))
+  }
+
+  func testGalleryPushCommunicationIntentUsesTheGalleryAsSender() throws {
+    let jpeg = try XCTUnwrap(
+      UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).image { _ in }.jpegData(compressionQuality: 0.9)
+    )
+    let intent = GalleryPushCommunication.makeSendMessageIntent(
+      galleryName: "Street Photo",
+      gallerySlug: "street-photo",
+      body: "Just published a new photo.",
+      avatarData: jpeg
+    )
+
+    XCTAssertEqual(intent.sender?.displayName, "Street Photo")
+    XCTAssertEqual(intent.sender?.customIdentifier, "street-photo")
+    XCTAssertEqual(intent.conversationIdentifier, "street-photo")
+    XCTAssertEqual(intent.serviceName, "Afilmory")
+    XCTAssertEqual(intent.content, "Just published a new photo.")
+    XCTAssertNotNil(intent.sender?.image)
+  }
+
+  func testGalleryPushImageAttachmentRejectsEmptyAndOversizedData() {
+    XCTAssertThrowsError(try GalleryPushImageAttachment.makeAttachment(from: Data()))
+    XCTAssertThrowsError(try GalleryPushImageAttachment.makeAttachment(from: Data(count: 5 * 1024 * 1024 + 1)))
   }
 
   func testUnrelatedNotificationDoesNotProduceADeepLink() {

--- a/apps/mobile/project.yml
+++ b/apps/mobile/project.yml
@@ -54,6 +54,8 @@ targets:
         embed: true
       - target: AfilmoryWidgets
         embed: true
+      - target: AfilmoryNotification
+        embed: true
     info:
       path: Afilmory/Info.plist
       properties:
@@ -87,6 +89,8 @@ targets:
               NSIncludesSubdomains: true
         NSPhotoLibraryAddUsageDescription: Allow Afilmory to save photos to your library.
         NSPhotoLibraryUsageDescription: Allow Afilmory Studio to select photos for your gallery.
+        NSUserActivityTypes:
+          - INSendMessageIntent
         NSSupportsLiveActivities: true
         UIBackgroundModes:
           - remote-notification
@@ -202,6 +206,42 @@ targets:
         Release:
           CODE_SIGN_ENTITLEMENTS: targets/widgets/AfilmoryWidgets.entitlements
           PRODUCT_BUNDLE_IDENTIFIER: app.afilmory.widgets
+
+  AfilmoryNotification:
+    type: app-extension
+    platform: iOS
+    deploymentTarget: "18.0"
+    sources:
+      - path: targets/notification
+        type: syncedFolder
+      - path: Afilmory/Core/Push/GalleryPushImageAttachment.swift
+        group: Afilmory/Core/Push
+      - path: Afilmory/Core/Push/GalleryPushCommunication.swift
+        group: Afilmory/Core/Push
+    dependencies:
+      - sdk: Intents.framework
+    info:
+      path: targets/notification/Info.plist
+      properties:
+        CFBundleDisplayName: Afilmory
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.usernotifications.service
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService"
+    settings:
+      base:
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: "1.4"
+        PRODUCT_MODULE_NAME: AfilmoryNotification
+        PRODUCT_NAME: AfilmoryNotification
+        SKIP_INSTALL: YES
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: app.afilmory.local.notification
+        Release:
+          CODE_SIGN_ENTITLEMENTS: targets/notification/AfilmoryNotification.entitlements
+          PRODUCT_BUNDLE_IDENTIFIER: app.afilmory.notification
 
   AfilmoryTests:
     type: bundle.unit-test

--- a/apps/mobile/scripts/configure-ci-signing.rb
+++ b/apps/mobile/scripts/configure-ci-signing.rb
@@ -11,6 +11,7 @@ profiles = {
   'Afilmory' => ENV.fetch('IOS_APP_PROFILE_NAME'),
   'AfilmoryShare' => ENV.fetch('IOS_SHARE_PROFILE_NAME'),
   'AfilmoryWidgets' => ENV.fetch('IOS_WIDGETS_PROFILE_NAME'),
+  'AfilmoryNotification' => ENV.fetch('IOS_NOTIFICATION_PROFILE_NAME'),
 }
 
 project = Xcodeproj::Project.open(project_path)

--- a/apps/mobile/scripts/import-ci-signing-assets.sh
+++ b/apps/mobile/scripts/import-ci-signing-assets.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 : "${APP_PROFILE_BASE64:?APP_PROFILE_BASE64 is required}"
 : "${SHARE_PROFILE_BASE64:?SHARE_PROFILE_BASE64 is required}"
 : "${WIDGETS_PROFILE_BASE64:?WIDGETS_PROFILE_BASE64 is required}"
+: "${NOTIFICATION_PROFILE_BASE64:?NOTIFICATION_PROFILE_BASE64 is required}"
 
 keychain_path="$RUNNER_TEMP/ci.keychain-db"
 keychain_password="$(uuidgen)"
@@ -112,3 +113,4 @@ install_profile() {
 install_profile "$APP_PROFILE_BASE64" 'app.afilmory' 'IOS_APP' 'group.app.afilmory'
 install_profile "$SHARE_PROFILE_BASE64" 'app.afilmory.share' 'IOS_SHARE' 'group.app.afilmory'
 install_profile "$WIDGETS_PROFILE_BASE64" 'app.afilmory.widgets' 'IOS_WIDGETS'
+install_profile "$NOTIFICATION_PROFILE_BASE64" 'app.afilmory.notification' 'IOS_NOTIFICATION'

--- a/apps/mobile/scripts/import-ci-signing-assets.sh
+++ b/apps/mobile/scripts/import-ci-signing-assets.sh
@@ -47,6 +47,7 @@ install_profile() {
   local expected_bundle_id="$2"
   local output_prefix="$3"
   local required_app_group="${4:-}"
+  local require_communication="${5:-false}"
   local source_path="$RUNNER_TEMP/${output_prefix}.mobileprovision"
   local plist_path="$RUNNER_TEMP/${output_prefix}.plist"
 
@@ -100,6 +101,17 @@ install_profile() {
       exit 1
     fi
   fi
+  if [[ "$require_communication" == 'true' ]]; then
+    local communication
+    communication="$(
+      /usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.usernotifications.communication' "$plist_path" 2>/dev/null \
+        || true
+    )"
+    if [[ "$communication" != 'true' ]]; then
+      echo "Provisioning profile for $expected_bundle_id does not include Communication Notifications." >&2
+      exit 1
+    fi
+  fi
 
   cp "$source_path" "$legacy_profiles_directory/$profile_uuid.mobileprovision"
   cp "$source_path" "$xcode_profiles_directory/$profile_uuid.mobileprovision"
@@ -110,7 +122,7 @@ install_profile() {
   printf 'Installed App Store profile %s for %s (%s).\n' "$profile_name" "$expected_bundle_id" "$profile_uuid"
 }
 
-install_profile "$APP_PROFILE_BASE64" 'app.afilmory' 'IOS_APP' 'group.app.afilmory'
+install_profile "$APP_PROFILE_BASE64" 'app.afilmory' 'IOS_APP' 'group.app.afilmory' true
 install_profile "$SHARE_PROFILE_BASE64" 'app.afilmory.share' 'IOS_SHARE' 'group.app.afilmory'
 install_profile "$WIDGETS_PROFILE_BASE64" 'app.afilmory.widgets' 'IOS_WIDGETS'
-install_profile "$NOTIFICATION_PROFILE_BASE64" 'app.afilmory.notification' 'IOS_NOTIFICATION'
+install_profile "$NOTIFICATION_PROFILE_BASE64" 'app.afilmory.notification' 'IOS_NOTIFICATION' '' true

--- a/apps/mobile/targets/notification/AfilmoryNotification.entitlements
+++ b/apps/mobile/targets/notification/AfilmoryNotification.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.developer.usernotifications.communication</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/mobile/targets/notification/Info.plist
+++ b/apps/mobile/targets/notification/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Afilmory</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/mobile/targets/notification/NotificationService.swift
+++ b/apps/mobile/targets/notification/NotificationService.swift
@@ -39,24 +39,65 @@ final class NotificationService: UNNotificationServiceExtension {
       return
     }
 
-    download(avatarURL) { [weak self] avatarData in
+    var remaining = (avatarURL != nil ? 1 : 0) + (imageURL != nil ? 1 : 0)
+    if remaining == 0 {
+      applyCommunication(to: content, identity: identity, avatarData: nil)
+      return
+    }
+
+    var avatarData: Data?
+
+    let completeOne = { [weak self] in
       guard let self else { return }
-      self.download(imageURL) { imageData in
+      self.lock.lock()
+      remaining -= 1
+      let done = remaining == 0
+      let avatar = avatarData
+      let finished = self.didFinish
+      self.lock.unlock()
+      guard done, !finished else { return }
+      self.applyCommunication(to: content, identity: identity, avatarData: avatar)
+    }
+
+    if let imageURL {
+      download(imageURL) { [weak self] imageData in
+        guard let self else {
+          completeOne()
+          return
+        }
         if let imageData,
            let attachment = try? GalleryPushImageAttachment.makeAttachment(from: imageData)
         {
+          self.lock.lock()
           content.attachments = [attachment]
+          self.lock.unlock()
           Self.log.info(
             "attached id=\(attachment.identifier, privacy: .public) type=\(attachment.type, privacy: .public) path=\(attachment.url.lastPathComponent, privacy: .public)"
           )
         }
-        self.applyCommunication(to: content, identity: identity, avatarData: avatarData)
+        completeOne()
+      }
+    }
+
+    if let avatarURL {
+      download(avatarURL) { [weak self] data in
+        guard let self else {
+          completeOne()
+          return
+        }
+        self.lock.lock()
+        avatarData = data
+        self.lock.unlock()
+        completeOne()
       }
     }
   }
 
   override func serviceExtensionTimeWillExpire() {
-    downloadTasks.forEach { $0.cancel() }
+    lock.lock()
+    let tasks = downloadTasks
+    lock.unlock()
+    tasks.forEach { $0.cancel() }
     finish(with: bestAttemptContent)
   }
 
@@ -83,11 +124,7 @@ final class NotificationService: UNNotificationServiceExtension {
     }
   }
 
-  private func download(_ url: URL?, completion: @escaping (Data?) -> Void) {
-    guard let url else {
-      completion(nil)
-      return
-    }
+  private func download(_ url: URL, completion: @escaping (Data?) -> Void) {
     let task = Self.session.dataTask(with: url) { [weak self] data, response, _ in
       guard let self else { return }
       self.lock.lock()
@@ -103,7 +140,9 @@ final class NotificationService: UNNotificationServiceExtension {
       }
       completion(data)
     }
+    lock.lock()
     downloadTasks.append(task)
+    lock.unlock()
     task.resume()
   }
 

--- a/apps/mobile/targets/notification/NotificationService.swift
+++ b/apps/mobile/targets/notification/NotificationService.swift
@@ -1,0 +1,120 @@
+import os
+import UserNotifications
+
+final class NotificationService: UNNotificationServiceExtension {
+  private let lock = NSLock()
+  private var bestAttemptContent: UNMutableNotificationContent?
+  private var contentHandler: ((UNNotificationContent) -> Void)?
+  private var downloadTasks: [URLSessionDataTask] = []
+  private var didFinish = false
+  private static let log = Logger(subsystem: "app.afilmory.notification", category: "NSE")
+
+  private static let session: URLSession = {
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = 15
+    configuration.timeoutIntervalForResource = 20
+    configuration.waitsForConnectivity = false
+    return URLSession(configuration: configuration)
+  }()
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    self.contentHandler = contentHandler
+    let content = request.content.mutableCopy() as? UNMutableNotificationContent
+    bestAttemptContent = content
+
+    guard let content else {
+      finish(with: request.content)
+      return
+    }
+
+    let identity = GalleryPushCommunication.galleryIdentity(from: request.content.userInfo)
+    let avatarURL = GalleryPushImageAttachment.remoteAvatarURL(from: request.content.userInfo)
+    let imageURL = GalleryPushImageAttachment.remoteImageURL(from: request.content.userInfo)
+
+    guard identity != nil || avatarURL != nil || imageURL != nil else {
+      finish(with: content)
+      return
+    }
+
+    download(avatarURL) { [weak self] avatarData in
+      guard let self else { return }
+      self.download(imageURL) { imageData in
+        if let imageData,
+           let attachment = try? GalleryPushImageAttachment.makeAttachment(from: imageData)
+        {
+          content.attachments = [attachment]
+          Self.log.info(
+            "attached id=\(attachment.identifier, privacy: .public) type=\(attachment.type, privacy: .public) path=\(attachment.url.lastPathComponent, privacy: .public)"
+          )
+        }
+        self.applyCommunication(to: content, identity: identity, avatarData: avatarData)
+      }
+    }
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    downloadTasks.forEach { $0.cancel() }
+    finish(with: bestAttemptContent)
+  }
+
+  private func applyCommunication(
+    to content: UNMutableNotificationContent,
+    identity: (name: String, slug: String)?,
+    avatarData: Data?
+  ) {
+    lock.lock()
+    let finished = didFinish
+    lock.unlock()
+    guard !finished else { return }
+    guard let identity else {
+      finish(with: content)
+      return
+    }
+    GalleryPushCommunication.donateAndUpdate(
+      content,
+      galleryName: identity.name,
+      gallerySlug: identity.slug,
+      avatarData: avatarData
+    ) { [weak self] updated in
+      self?.finish(with: updated)
+    }
+  }
+
+  private func download(_ url: URL?, completion: @escaping (Data?) -> Void) {
+    guard let url else {
+      completion(nil)
+      return
+    }
+    let task = Self.session.dataTask(with: url) { [weak self] data, response, _ in
+      guard let self else { return }
+      self.lock.lock()
+      let finished = self.didFinish
+      self.lock.unlock()
+      guard !finished else { return }
+      guard let data,
+            let http = response as? HTTPURLResponse,
+            (200..<300).contains(http.statusCode)
+      else {
+        completion(nil)
+        return
+      }
+      completion(data)
+    }
+    downloadTasks.append(task)
+    task.resume()
+  }
+
+  private func finish(with content: UNNotificationContent?) {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !didFinish, let contentHandler else { return }
+    didFinish = true
+    self.contentHandler = nil
+    downloadTasks.forEach { $0.cancel() }
+    downloadTasks = []
+    contentHandler(content ?? UNNotificationContent())
+  }
+}

--- a/be/apps/core/src/modules/content/photo/assets/photo-asset.service.ts
+++ b/be/apps/core/src/modules/content/photo/assets/photo-asset.service.ts
@@ -28,6 +28,7 @@ import { quotaExceeded } from '@core/modules/platform/billing/quota/billing-quot
 import { BILLING_USAGE_EVENT } from '@core/modules/platform/billing/usage/billing-usage.constants'
 import { BillingUsageService } from '@core/modules/platform/billing/usage/billing-usage.service'
 import { ManagedStorageService } from '@core/modules/platform/managed-storage/managed-storage.service'
+import { selectGalleryPushPreview } from '@core/modules/platform/push-notifications/gallery-push.payload'
 import { GalleryPushQueue } from '@core/modules/platform/push-notifications/gallery-push.queue'
 import { requireTenantContext } from '@core/modules/platform/tenant/tenant.context'
 import { createLogger } from '@tsuki-hono/common'
@@ -597,9 +598,20 @@ export class PhotoAssetService {
             uploadSource: 'manual-upload',
           },
         })
-        await this.galleryPushQueue.enqueueGalleryPublished(tenant.tenant.id, processedItems.length).catch((error) => {
-          this.logger.error('Failed to queue gallery update notifications', error)
-        })
+        await this.galleryPushQueue
+          .enqueueGalleryPublished(
+            tenant.tenant.id,
+            processedItems.length,
+            selectGalleryPushPreview(
+              processedItems.map(item => ({
+                photoId: item.photoId,
+                thumbnailUrl: item.manifest?.data?.thumbnailUrl,
+              })),
+            ),
+          )
+          .catch((error) => {
+            this.logger.error('Failed to queue gallery update notifications', error)
+          })
       }
 
       shouldRollbackUploads = false

--- a/be/apps/core/src/modules/infrastructure/data-sync/data-sync.service.ts
+++ b/be/apps/core/src/modules/infrastructure/data-sync/data-sync.service.ts
@@ -14,6 +14,7 @@ import { BillingPlanService } from '@core/modules/platform/billing/plan/billing-
 import { quotaExceeded } from '@core/modules/platform/billing/quota/billing-quota.error'
 import { BILLING_USAGE_EVENT } from '@core/modules/platform/billing/usage/billing-usage.constants'
 import { BillingUsageService } from '@core/modules/platform/billing/usage/billing-usage.service'
+import { selectGalleryPushPreview } from '@core/modules/platform/push-notifications/gallery-push.payload'
 import { GalleryPushQueue } from '@core/modules/platform/push-notifications/gallery-push.queue'
 import { requireTenantContext } from '@core/modules/platform/tenant/tenant.context'
 import { createLogger } from '@tsuki-hono/common'
@@ -206,11 +207,22 @@ export class DataSyncService {
       if (mutated) {
         await this.manifestSyncService.recordAppliedActions(tenant.tenant.id, actions)
       }
-      const insertedCount = actions.filter(action => action.type === 'insert' && action.applied).length
-      if (insertedCount > 0) {
-        await this.galleryPushQueue.enqueueGalleryPublished(tenant.tenant.id, insertedCount).catch((error) => {
-          this.logger.error('Failed to queue gallery update notifications', error)
-        })
+      const inserted = actions.filter(action => action.type === 'insert' && action.applied)
+      if (inserted.length > 0) {
+        await this.galleryPushQueue
+          .enqueueGalleryPublished(
+            tenant.tenant.id,
+            inserted.length,
+            selectGalleryPushPreview(
+              inserted.map(action => ({
+                photoId: action.photoId,
+                thumbnailUrl: action.manifestAfter?.thumbnailUrl,
+              })),
+            ),
+          )
+          .catch((error) => {
+            this.logger.error('Failed to queue gallery update notifications', error)
+          })
       }
     }
 

--- a/be/apps/core/src/modules/platform/push-notifications/apns.provider.ts
+++ b/be/apps/core/src/modules/platform/push-notifications/apns.provider.ts
@@ -9,6 +9,8 @@ import { createLogger } from '@tsuki-hono/common'
 import { injectable } from 'tsyringe'
 
 import { classifyAPNsResponse, createAPNsProviderToken } from './apns.utils'
+import type { GalleryPushNotification } from './gallery-push.payload'
+import { buildGalleryPushAPNsPayload } from './gallery-push.payload'
 import type { APNsEnvironment } from './push-device.service'
 
 const APNS_ORIGINS: Record<APNsEnvironment, string> = {
@@ -26,14 +28,8 @@ interface APNsProviderConfiguration {
   teamId: string
 }
 
-export interface GalleryPushPayload {
+export interface GalleryPushPayload extends GalleryPushNotification {
   deliveryId: string
-  eventId: string
-  galleryName: string
-  gallerySlug: string
-  photoCount: number
-  body: string
-  title: string
 }
 
 export interface APNsSendResult {
@@ -101,21 +97,7 @@ export class APNsProvider {
     notification: GalleryPushPayload,
   ): Promise<APNsSendResult> {
     const configuration = this.configuration!
-    const payload = JSON.stringify({
-      aps: {
-        'alert': {
-          body: notification.body,
-          title: notification.title,
-        },
-        'sound': 'default',
-        'thread-id': `gallery:${notification.gallerySlug}`,
-      },
-      eventId: notification.eventId,
-      galleryName: notification.galleryName,
-      gallerySlug: notification.gallerySlug,
-      photoCount: notification.photoCount,
-      route: 'gallery',
-    })
+    const payload = JSON.stringify(buildGalleryPushAPNsPayload(notification))
 
     try {
       const session = this.sessionFor(environment)

--- a/be/apps/core/src/modules/platform/push-notifications/gallery-push.payload.spec.ts
+++ b/be/apps/core/src/modules/platform/push-notifications/gallery-push.payload.spec.ts
@@ -1,0 +1,183 @@
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it } from 'vitest'
+
+import { buildGalleryPushAPNsPayload, selectGalleryPushPreview } from './gallery-push.payload'
+
+const notification = {
+  body: 'Just published a new photo.',
+  eventId: 'event-1',
+  galleryName: 'Street',
+  gallerySlug: 'street',
+  photoCount: 1,
+  title: 'Street',
+}
+
+describe('selectGalleryPushPreview', () => {
+  it('picks the last item that has a public https thumbnail', () => {
+    expect(
+      selectGalleryPushPreview([
+        { photoId: 'a', thumbnailUrl: 'https://cdn.example/a.jpg' },
+        { photoId: 'b', thumbnailUrl: '/thumbnails/b.jpg' },
+        { photoId: 'c', thumbnailUrl: 'https://cdn.example/c.jpg' },
+      ]),
+    ).toEqual({
+      imageUrl: 'https://cdn.example/c.jpg',
+      photoId: 'c',
+    })
+  })
+
+  it('walks backward past http, relative, and empty thumbnails', () => {
+    expect(
+      selectGalleryPushPreview([
+        { photoId: 'a', thumbnailUrl: 'https://cdn.example/a.jpg' },
+        { photoId: 'b', thumbnailUrl: 'http://cdn.example/b.jpg' },
+        { photoId: null, thumbnailUrl: 'https://cdn.example/c.jpg' },
+        { photoId: 'd', thumbnailUrl: '  ' },
+      ]),
+    ).toEqual({
+      imageUrl: 'https://cdn.example/a.jpg',
+      photoId: 'a',
+    })
+  })
+
+  it('keeps signed query strings on the thumbnail url', () => {
+    expect(
+      selectGalleryPushPreview([
+        {
+          photoId: 'a',
+          thumbnailUrl: 'https://cdn.example/t.jpg?X-Amz-Signature=abc%2Fdef&foo=1',
+        },
+      ]),
+    ).toEqual({
+      imageUrl: 'https://cdn.example/t.jpg?X-Amz-Signature=abc%2Fdef&foo=1',
+      photoId: 'a',
+    })
+  })
+
+  it('returns null when no published photo has a public https thumbnail', () => {
+    expect(
+      selectGalleryPushPreview([
+        { photoId: 'a', thumbnailUrl: 'http://cdn.example/a.jpg' },
+        { photoId: 'b', thumbnailUrl: '/thumbnails/b.jpg' },
+      ]),
+    ).toBeNull()
+  })
+})
+
+describe('buildGalleryPushAPNsPayload', () => {
+  it('keeps the existing text payload when there is no image', () => {
+    expect(buildGalleryPushAPNsPayload(notification)).toEqual({
+      aps: {
+        'alert': {
+          body: 'Just published a new photo.',
+          title: 'Street',
+        },
+        'sound': 'default',
+        'thread-id': 'gallery:street',
+      },
+      eventId: 'event-1',
+      galleryName: 'Street',
+      gallerySlug: 'street',
+      photoCount: 1,
+      route: 'gallery',
+    })
+  })
+
+  it('adds mutable-content, the owner avatar, and the https thumbnail', () => {
+    expect(
+      buildGalleryPushAPNsPayload({
+        ...notification,
+        avatarUrl: 'https://cdn.example/me.jpg',
+        imageUrl: 'https://cdn.example/t.jpg',
+        photoId: 'DSC_1',
+      }),
+    ).toEqual({
+      aps: {
+        'alert': {
+          body: 'Just published a new photo.',
+          title: 'Street',
+        },
+        'mutable-content': 1,
+        'sound': 'default',
+        'thread-id': 'gallery:street',
+      },
+      avatarUrl: 'https://cdn.example/me.jpg',
+      eventId: 'event-1',
+      galleryName: 'Street',
+      gallerySlug: 'street',
+      imageUrl: 'https://cdn.example/t.jpg',
+      photoCount: 1,
+      photoId: 'DSC_1',
+      route: 'gallery',
+    })
+  })
+
+  it('adds mutable-content when only the owner avatar is present', () => {
+    expect(
+      buildGalleryPushAPNsPayload({
+        ...notification,
+        avatarUrl: 'https://cdn.example/me.jpg',
+      }),
+    ).toMatchObject({
+      aps: { 'mutable-content': 1 },
+      avatarUrl: 'https://cdn.example/me.jpg',
+    })
+  })
+
+  it('drops the image when the payload would exceed the APNs size limit', () => {
+    const payload = buildGalleryPushAPNsPayload({
+      ...notification,
+      imageUrl: `https://cdn.example/${'a'.repeat(5000)}.jpg`,
+      photoId: 'DSC_1',
+    })
+
+    expect(payload).toMatchObject({
+      photoId: 'DSC_1',
+      route: 'gallery',
+    })
+    expect(payload).not.toHaveProperty('imageUrl')
+    expect(payload.aps).not.toHaveProperty('mutable-content')
+    expect(Buffer.byteLength(JSON.stringify(payload), 'utf8')).toBeLessThanOrEqual(4096)
+  })
+
+  it('keeps the owner avatar when the thumbnail would exceed the APNs size limit', () => {
+    const payload = buildGalleryPushAPNsPayload({
+      ...notification,
+      avatarUrl: 'https://cdn.example/me.jpg',
+      imageUrl: `https://cdn.example/${'a'.repeat(5000)}.jpg`,
+      photoId: 'DSC_1',
+    })
+
+    expect(payload).toMatchObject({
+      avatarUrl: 'https://cdn.example/me.jpg',
+      photoId: 'DSC_1',
+    })
+    expect(payload).not.toHaveProperty('imageUrl')
+    expect(payload.aps).toMatchObject({ 'mutable-content': 1 })
+  })
+
+  it('ignores a non-https image url', () => {
+    const payload = buildGalleryPushAPNsPayload({
+      ...notification,
+      imageUrl: 'http://cdn.example/t.jpg',
+      photoId: 'DSC_1',
+    })
+
+    expect(payload).not.toHaveProperty('imageUrl')
+    expect(payload.aps).not.toHaveProperty('mutable-content')
+    expect(payload).toMatchObject({ photoId: 'DSC_1' })
+  })
+
+  it('ignores a non-https owner avatar url', () => {
+    const payload = buildGalleryPushAPNsPayload({
+      ...notification,
+      avatarUrl: 'http://cdn.example/me.jpg',
+      photoId: 'DSC_1',
+    })
+
+    expect(payload).not.toHaveProperty('avatarUrl')
+    expect(payload.aps).not.toHaveProperty('mutable-content')
+    expect(payload).toMatchObject({ photoId: 'DSC_1' })
+  })
+})

--- a/be/apps/core/src/modules/platform/push-notifications/gallery-push.payload.ts
+++ b/be/apps/core/src/modules/platform/push-notifications/gallery-push.payload.ts
@@ -1,0 +1,127 @@
+import { Buffer } from 'node:buffer'
+
+const APNS_PAYLOAD_MAX_BYTES = 4096
+
+export type GalleryPushPreviewSource = {
+  photoId: string | null
+  thumbnailUrl: string | null | undefined
+}
+
+export type GalleryPushPreview = {
+  imageUrl: string
+  photoId: string
+}
+
+export type GalleryPushNotification = {
+  avatarUrl?: string
+  body: string
+  eventId: string
+  galleryName: string
+  gallerySlug: string
+  imageUrl?: string
+  photoCount: number
+  photoId?: string
+  title: string
+}
+
+type GalleryPushAPNsPayload = {
+  aps: {
+    'alert': {
+      body: string
+      title: string
+    }
+    'mutable-content'?: 1
+    'sound': 'default'
+    'thread-id': string
+  }
+  avatarUrl?: string
+  eventId: string
+  galleryName: string
+  gallerySlug: string
+  imageUrl?: string
+  photoCount: number
+  photoId?: string
+  route: 'gallery'
+}
+
+export function selectGalleryPushPreview(items: readonly GalleryPushPreviewSource[]): GalleryPushPreview | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]
+    if (!item?.photoId) {
+      continue
+    }
+    const imageUrl = publicHttpsImageUrl(item.thumbnailUrl)
+    if (!imageUrl) {
+      continue
+    }
+    return { imageUrl, photoId: item.photoId }
+  }
+  return null
+}
+
+export function buildGalleryPushAPNsPayload(notification: GalleryPushNotification): GalleryPushAPNsPayload {
+  const photoId = notification.photoId?.trim() || undefined
+  const imageUrl = publicHttpsImageUrl(notification.imageUrl)
+  const avatarUrl = publicHttpsImageUrl(notification.avatarUrl)
+  const candidates: Array<[string | undefined, string | undefined]> = [
+    [imageUrl, avatarUrl],
+    [undefined, avatarUrl],
+    [imageUrl, undefined],
+    [undefined, undefined],
+  ]
+  for (const [image, avatar] of candidates) {
+    const payload = serializePayload(notification, photoId, image, avatar)
+    if (utf8Bytes(payload) <= APNS_PAYLOAD_MAX_BYTES) {
+      return payload
+    }
+  }
+  return serializePayload(notification, photoId, undefined, undefined)
+}
+
+function serializePayload(
+  notification: GalleryPushNotification,
+  photoId: string | undefined,
+  imageUrl: string | undefined,
+  avatarUrl: string | undefined,
+): GalleryPushAPNsPayload {
+  return {
+    aps: {
+      'alert': {
+        body: notification.body,
+        title: notification.title,
+      },
+      ...(imageUrl || avatarUrl ? { 'mutable-content': 1 as const } : {}),
+      'sound': 'default',
+      'thread-id': `gallery:${notification.gallerySlug}`,
+    },
+    ...(avatarUrl ? { avatarUrl } : {}),
+    eventId: notification.eventId,
+    galleryName: notification.galleryName,
+    gallerySlug: notification.gallerySlug,
+    ...(imageUrl ? { imageUrl } : {}),
+    photoCount: notification.photoCount,
+    ...(photoId ? { photoId } : {}),
+    route: 'gallery',
+  }
+}
+
+function publicHttpsImageUrl(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== 'https:' || !url.hostname) {
+      return undefined
+    }
+    return trimmed
+  }
+  catch {
+    return undefined
+  }
+}
+
+function utf8Bytes(payload: GalleryPushAPNsPayload): number {
+  return Buffer.byteLength(JSON.stringify(payload), 'utf8')
+}

--- a/be/apps/core/src/modules/platform/push-notifications/gallery-push.queue.ts
+++ b/be/apps/core/src/modules/platform/push-notifications/gallery-push.queue.ts
@@ -8,18 +8,22 @@ import { injectable } from 'tsyringe'
 import { APNsProvider } from './apns.provider'
 import { alternateAPNsEnvironment } from './apns.utils'
 import { galleryPushBody } from './gallery-push.copy'
+import type { GalleryPushPreview } from './gallery-push.payload'
 import { PushDeviceService } from './push-device.service'
 
 const QUEUE_NAME = 'gallery-push-notifications'
 const TASK_NAME = 'send-gallery-update'
 
 interface GalleryPushTaskPayload {
+  avatarUrl?: string
   deliveryId: string
   deviceId: string
   eventId: string
   galleryName: string
   gallerySlug: string
+  imageUrl?: string
   photoCount: number
+  photoId?: string
   targetTenantId: string
 }
 
@@ -62,7 +66,11 @@ export class GalleryPushQueue {
     await this.workerRedis.quit()
   }
 
-  async enqueueGalleryPublished(targetTenantId: string, photoCount: number): Promise<void> {
+  async enqueueGalleryPublished(
+    targetTenantId: string,
+    photoCount: number,
+    preview?: GalleryPushPreview | null,
+  ): Promise<void> {
     if (!this.apnsProvider.isConfigured() || photoCount <= 0) {
       return
     }
@@ -80,12 +88,15 @@ export class GalleryPushQueue {
           id: deliveryId,
           name: TASK_NAME,
           payload: {
+            avatarUrl: recipients.gallery!.avatarUrl,
             deliveryId,
             deviceId,
             eventId,
             galleryName: recipients.gallery!.name,
             gallerySlug: recipients.gallery!.slug,
+            imageUrl: preview?.imageUrl,
             photoCount,
+            photoId: preview?.photoId,
             targetTenantId,
           },
         })
@@ -111,13 +122,16 @@ export class GalleryPushQueue {
     }
 
     const notification = {
+      avatarUrl: payload.avatarUrl,
+      body: galleryPushBody(device.locale, payload.photoCount),
       deliveryId: payload.deliveryId,
       eventId: payload.eventId,
       galleryName: payload.galleryName,
       gallerySlug: payload.gallerySlug,
+      imageUrl: payload.imageUrl,
       photoCount: payload.photoCount,
+      photoId: payload.photoId,
       title: payload.galleryName,
-      body: galleryPushBody(device.locale, payload.photoCount),
     }
     let result = await this.apnsProvider.send(device.deviceToken, device.environment, notification)
 

--- a/be/apps/core/src/modules/platform/push-notifications/push-device.service.ts
+++ b/be/apps/core/src/modules/platform/push-notifications/push-device.service.ts
@@ -1,4 +1,4 @@
-import { apnsDevices, gallerySubscriptions, tenants } from '@afilmory/db'
+import { apnsDevices, authUsers, gallerySubscriptions, tenantMemberships, tenants } from '@afilmory/db'
 import { DbAccessor } from '@core/database/database.provider'
 import { and, eq } from 'drizzle-orm'
 import { injectable } from 'tsyringe'
@@ -58,7 +58,7 @@ export class PushDeviceService {
   }
 
   async listGalleryRecipientDeviceIds(targetTenantId: string): Promise<{
-    gallery: { name: string, slug: string } | null
+    gallery: { avatarUrl?: string, name: string, slug: string } | null
     deviceIds: string[]
   }> {
     const db = this.dbAccessor.get()
@@ -67,6 +67,7 @@ export class PushDeviceService {
         deviceId: apnsDevices.id,
         galleryName: tenants.name,
         gallerySlug: tenants.slug,
+        ownerImage: authUsers.image,
       })
       .from(gallerySubscriptions)
       .innerJoin(
@@ -74,6 +75,15 @@ export class PushDeviceService {
         and(eq(apnsDevices.userId, gallerySubscriptions.subscriberUserId), eq(apnsDevices.enabled, true)),
       )
       .innerJoin(tenants, eq(tenants.id, gallerySubscriptions.targetTenantId))
+      .leftJoin(
+        tenantMemberships,
+        and(
+          eq(tenantMemberships.tenantId, tenants.id),
+          eq(tenantMemberships.role, 'owner'),
+          eq(tenantMemberships.status, 'active'),
+        ),
+      )
+      .leftJoin(authUsers, eq(authUsers.id, tenantMemberships.userId))
       .where(
         and(
           eq(gallerySubscriptions.targetTenantId, targetTenantId),
@@ -83,8 +93,15 @@ export class PushDeviceService {
       )
 
     const first = rows[0]
+    const avatarUrl = first?.ownerImage?.trim() || undefined
     return {
-      gallery: first ? { name: first.galleryName, slug: first.gallerySlug } : null,
+      gallery: first
+        ? {
+            ...(avatarUrl ? { avatarUrl } : {}),
+            name: first.galleryName,
+            slug: first.gallerySlug,
+          }
+        : null,
       deviceIds: rows.map(row => row.deviceId),
     }
   }


### PR DESCRIPTION
## Summary

Gallery subscription alerts now go out as Communication Notifications.

- Core sends `avatarUrl` (tenant owner `auth_user.image`) and `imageUrl` (published HTTPS thumbnail), with `mutable-content` when either is present.
- The Notification Service Extension downloads both, donates an incoming `INSendMessageIntent` with the owner as `INPerson`, and attaches the photo as `UNNotificationAttachment`.
- Tap opens Explore on that gallery and focuses the preview photo when `photoId` is present.
- TestFlight CI signs and embeds `app.afilmory.notification`.

## Verification

- `gallery-push.payload.spec.ts` and `PushNotificationTests` cover payload/HTTPS/deep-link/intent wiring.
- Local Core → APNs sandbox → iOS 26.5 Simulator: banner, owner avatar on the leading circle, tap opens the gallery. Long-press expansion shows the JPEG (`attachmentCount=1`).
- Compact trailing thumbnail was not observed on the iOS 26.5 Simulator even for attachment-only notifications (no Communication enrichment). Confirm that on a physical device.

## Notes

- Enable **Communication Notifications** on `app.afilmory` and `app.afilmory.notification` in the Developer portal / Xcode. The public App Store Connect capability enum does not include this type.
- Store the NSE App Store profile as `IOS_NOTIFICATION_APPSTORE_PROFILE`.
- Sandbox APNs verification is documented in `.agents/skills/verifying-afilmory-apns/`.