### PR TITLE
fix: stop ignoring metadata dirs so Tailwind scans web source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,3 @@ scripts/generate-app-store-composites.mjs
 .asc/
 tmp-asc/
 acceptance-report/
-metadata/


### PR DESCRIPTION
## Problem

Since d96a1a3d, root `.gitignore` contains an unanchored `metadata/` rule added for App Store acceptance artifacts. It matches **any** directory named `metadata` at any depth — including `apps/web/src/modules/metadata`.

Tailwind v4's content scanner honours `.gitignore`, so the whole directory was silently skipped: utility classes that only appear there (e.g. the mini map's `h-40` container and `animate-ping` marker) were never generated. The photo detail mini map rendered with 0 height — visible rows (EXIF lat/lon/altitude) were fine because they don't depend on those classes.

Git shows nothing wrong: the files are tracked, and ignore rules only affect untracked files.

## Fix

Remove the unanchored `metadata/` rule. No real `metadata/` artifact directories exist anywhere in the repo (checked), so nothing depends on it; if the acceptance tooling ever needs it again it should be anchored to the actual output path.

## Before / After

Same page, same photo, same commit — only the `.gitignore` rule differs.

**Before** (rule present → Tailwind skips `modules/metadata`): the mini map container collapses, nothing renders between the location rows and technical parameters.

![before](https://github.com/user-attachments/assets/3abe80f2-fab1-49f3-8979-e53cc48aed70)

**After** (rule removed → classes generated): the map renders at full height with the pulsing location marker.

![after](https://github.com/user-attachments/assets/11baea87-8373-4bb5-b664-4046bb1ccb09)

## Verification

- Oxide scanner candidate count for `apps/web` grows from 4400 → 4647; `h-40`, `animate-ping`, `bg-blue-400`, `ring-white/80` all appear.
- Production build CSS now contains the rules (`index.DWht0N.css` → `index.-qe1Jf.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)