### PR TITLE
feat(webgl-viewer): cycle double-tap through fit, fill and 100%

### DIFF
--- a/apps/web/src/modules/viewer/ContainedImageFrame.tsx
+++ b/apps/web/src/modules/viewer/ContainedImageFrame.tsx
@@ -9,7 +9,7 @@ interface ContainedImageFrameProps {
 
 export const ContainedImageFrame = ({ width, height, className, children }: ContainedImageFrameProps) => {
   const stageRef = useRef<HTMLDivElement>(null)
-  const [imageFrame, setImageFrame] = useState<{ width: number; height: number } | null>(null)
+  const [imageFrame, setImageFrame] = useState<{ width: number, height: number } | null>(null)
 
   const updateImageFrame = useCallback(() => {
     const stage = stageRef.current
@@ -34,7 +34,8 @@ export const ContainedImageFrame = ({ width, height, className, children }: Cont
     if (containerAspectRatio > imageAspectRatio) {
       nextHeight = containerHeight
       nextWidth = containerHeight * imageAspectRatio
-    } else {
+    }
+    else {
       nextWidth = containerWidth
       nextHeight = containerWidth / imageAspectRatio
     }

--- a/apps/web/src/modules/viewer/entry-animation-state.test.ts
+++ b/apps/web/src/modules/viewer/entry-animation-state.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
-import test from 'node:test'
+
+import { it } from 'vitest'
 
 import {
   getProgressiveImageVisualReady,
@@ -8,7 +9,7 @@ import {
   shouldHideCurrentViewerImage,
 } from './entry-animation-state'
 
-test('resolvePhotoViewerEntryState mounts the heavy image stage immediately when there is no trigger element', () => {
+it('resolvePhotoViewerEntryState mounts the heavy image stage immediately when there is no trigger element', () => {
   const state = resolvePhotoViewerEntryState({
     hasTransitionTrigger: false,
     isCurrentImageVisualReady: false,
@@ -23,7 +24,7 @@ test('resolvePhotoViewerEntryState mounts the heavy image stage immediately when
   })
 })
 
-test('resolvePhotoViewerEntryState keeps the lightweight catch-up layer hidden before the viewer stage is ready to hand off', () => {
+it('resolvePhotoViewerEntryState keeps the lightweight catch-up layer hidden before the viewer stage is ready to hand off', () => {
   const state = resolvePhotoViewerEntryState({
     hasTransitionTrigger: true,
     isCurrentImageVisualReady: false,
@@ -38,7 +39,7 @@ test('resolvePhotoViewerEntryState keeps the lightweight catch-up layer hidden b
   })
 })
 
-test('resolvePhotoViewerEntryState shows the lightweight catch-up layer only during the late entry handoff while the viewer stage is visible', () => {
+it('resolvePhotoViewerEntryState shows the lightweight catch-up layer only during the late entry handoff while the viewer stage is visible', () => {
   const state = resolvePhotoViewerEntryState({
     hasTransitionTrigger: true,
     isCurrentImageVisualReady: false,
@@ -53,7 +54,7 @@ test('resolvePhotoViewerEntryState shows the lightweight catch-up layer only dur
   })
 })
 
-test('resolvePhotoViewerEntryState drops the catch-up layer once the stage is visible and the current image is ready', () => {
+it('resolvePhotoViewerEntryState drops the catch-up layer once the stage is visible and the current image is ready', () => {
   const state = resolvePhotoViewerEntryState({
     hasTransitionTrigger: true,
     isCurrentImageVisualReady: true,
@@ -68,7 +69,7 @@ test('resolvePhotoViewerEntryState drops the catch-up layer once the stage is vi
   })
 })
 
-test('getProgressiveImageVisualReady treats a loaded thumbnail as enough to complete the entry handoff before the high-res layer renders', () => {
+it('getProgressiveImageVisualReady treats a loaded thumbnail as enough to complete the entry handoff before the high-res layer renders', () => {
   assert.equal(
     getProgressiveImageVisualReady({
       isHighResImageRendered: false,
@@ -79,7 +80,7 @@ test('getProgressiveImageVisualReady treats a loaded thumbnail as enough to comp
   )
 })
 
-test('getProgressiveImageVisualReady falls back to the high-res render state when there is no thumbnail', () => {
+it('getProgressiveImageVisualReady falls back to the high-res render state when there is no thumbnail', () => {
   assert.equal(
     getProgressiveImageVisualReady({
       isHighResImageRendered: true,
@@ -98,7 +99,7 @@ test('getProgressiveImageVisualReady falls back to the high-res render state whe
   )
 })
 
-test('isThumbnailElementVisuallyReady treats a thumbnail with resolved dimensions as ready even before the browser flips complete', () => {
+it('isThumbnailElementVisuallyReady treats a thumbnail with resolved dimensions as ready even before the browser flips complete', () => {
   assert.equal(
     isThumbnailElementVisuallyReady({
       currentSrc: 'https://zeta.ichr.me/gallery/thumbnails/20260404-SGL_3042.jpg',
@@ -120,7 +121,7 @@ test('isThumbnailElementVisuallyReady treats a thumbnail with resolved dimension
   )
 })
 
-test('shouldHideCurrentViewerImage keeps the real current slide hidden only while the catch-up layer owns the handoff', () => {
+it('shouldHideCurrentViewerImage keeps the real current slide hidden only while the catch-up layer owns the handoff', () => {
   assert.equal(
     shouldHideCurrentViewerImage({
       isCurrentImage: true,

--- a/packages/webgl-viewer/package.json
+++ b/packages/webgl-viewer/package.json
@@ -12,6 +12,8 @@
   "main": "./src/index.ts",
   "scripts": {
     "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -37,6 +39,7 @@
     "react": "^19.2.7",
     "tsdown": "0.22.2",
     "unplugin-dts": "1.0.2",
-    "vite": "8.0.16"
+    "vite": "8.0.16",
+    "vitest": "4.1.9"
   }
 }

--- a/packages/webgl-viewer/src/ImageViewerEngineBase.ts
+++ b/packages/webgl-viewer/src/ImageViewerEngineBase.ts
@@ -1,3 +1,10 @@
+import type { ViewportScaleInput } from './double-click-zoom'
+import {
+  computeFillScale,
+  computeFitScale,
+  resolveDoubleClickZoomStages,
+  resolveNextDoubleClickScale,
+} from './double-click-zoom'
 import type { LoadingState } from './enum'
 import type { ImageViewerOptions, ImageViewportState } from './interface'
 
@@ -110,8 +117,6 @@ export abstract class ImageViewerEngineBase {
   protected lastTouchDistance = 0
 
   protected lastDoubleClickTime = 0
-
-  protected isOriginalSize = false
 
   protected lastTouchTime = 0
 
@@ -298,20 +303,28 @@ export abstract class ImageViewerEngineBase {
   }
 
   protected fitImageToScreen() {
-    const scaleX = this.canvasWidth / this.imageWidth
-    const scaleY = this.canvasHeight / this.imageHeight
-    const fitToScreenScale = Math.min(scaleX, scaleY)
+    const fitToScreenScale = this.getFitToScreenScale()
 
     this.scale = fitToScreenScale * this.config.initialScale
     this.translateX = 0
     this.translateY = 0
-    this.isOriginalSize = false
   }
 
   protected getFitToScreenScale(): number {
-    const scaleX = this.canvasWidth / this.imageWidth
-    const scaleY = this.canvasHeight / this.imageHeight
-    return Math.min(scaleX, scaleY)
+    return computeFitScale(this.getViewportScaleInput())
+  }
+
+  protected getFillToScreenScale(): number {
+    return computeFillScale(this.getViewportScaleInput())
+  }
+
+  protected getViewportScaleInput(): ViewportScaleInput {
+    return {
+      canvasWidth: this.canvasWidth,
+      canvasHeight: this.canvasHeight,
+      imageWidth: this.imageWidth,
+      imageHeight: this.imageHeight,
+    }
   }
 
   protected constrainImagePosition() {
@@ -647,37 +660,30 @@ export abstract class ImageViewerEngineBase {
   protected performDoubleClickAction(x: number, y: number) {
     this.isAnimating = false
 
-    if (this.config.doubleClick.mode === 'toggle') {
-      const fitToScreenScale = this.getFitToScreenScale()
-      const absoluteMinScale = fitToScreenScale * this.config.minScale
-      const originalSizeScale = 1
-      const userMaxScale = fitToScreenScale * this.config.maxScale
-      const effectiveMaxScale = Math.max(userMaxScale, originalSizeScale)
-
-      if (this.isOriginalSize) {
-        const targetScale = Math.max(absoluteMinScale, Math.min(effectiveMaxScale, fitToScreenScale))
-        const zoomX = (x - this.canvasWidth / 2 - this.translateX) / this.scale
-        const zoomY = (y - this.canvasHeight / 2 - this.translateY) / this.scale
-        const targetTranslateX = x - this.canvasWidth / 2 - zoomX * targetScale
-        const targetTranslateY = y - this.canvasHeight / 2 - zoomY * targetScale
-
-        this.startAnimation(targetScale, targetTranslateX, targetTranslateY, this.config.doubleClick.animationTime)
-        this.isOriginalSize = false
-      }
-      else {
-        const targetScale = Math.max(absoluteMinScale, Math.min(effectiveMaxScale, originalSizeScale))
-        const zoomX = (x - this.canvasWidth / 2 - this.translateX) / this.scale
-        const zoomY = (y - this.canvasHeight / 2 - this.translateY) / this.scale
-        const targetTranslateX = x - this.canvasWidth / 2 - zoomX * targetScale
-        const targetTranslateY = y - this.canvasHeight / 2 - zoomY * targetScale
-
-        this.startAnimation(targetScale, targetTranslateX, targetTranslateY, this.config.doubleClick.animationTime)
-        this.isOriginalSize = true
-      }
-    }
-    else {
+    if (this.config.doubleClick.mode !== 'toggle') {
       this.zoomAt(x, y, this.config.doubleClick.step, true)
+      return
     }
+
+    const fitToScreenScale = this.getFitToScreenScale()
+    const absoluteMinScale = fitToScreenScale * this.config.minScale
+    const userMaxScale = fitToScreenScale * this.config.maxScale
+    const effectiveMaxScale = Math.max(userMaxScale, 1)
+    const originalSizeScale = Math.max(absoluteMinScale, Math.min(effectiveMaxScale, 1))
+
+    const stages = resolveDoubleClickZoomStages({
+      fitScale: fitToScreenScale,
+      fillScale: this.getFillToScreenScale(),
+      originalScale: originalSizeScale,
+    })
+    const targetScale = resolveNextDoubleClickScale(this.scale, stages)
+
+    const zoomX = (x - this.canvasWidth / 2 - this.translateX) / this.scale
+    const zoomY = (y - this.canvasHeight / 2 - this.translateY) / this.scale
+    const targetTranslateX = x - this.canvasWidth / 2 - zoomX * targetScale
+    const targetTranslateY = y - this.canvasHeight / 2 - zoomY * targetScale
+
+    this.startAnimation(targetScale, targetTranslateX, targetTranslateY, this.config.doubleClick.animationTime)
   }
 
   public zoomAt(x: number, y: number, scaleFactor: number, animated = false) {

--- a/packages/webgl-viewer/src/double-click-zoom.test.ts
+++ b/packages/webgl-viewer/src/double-click-zoom.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="node" />
+import assert from 'node:assert/strict'
+
+import { it } from 'vitest'
+
+import {
+  computeFillScale,
+  computeFitScale,
+  resolveDoubleClickZoomStages,
+  resolveNextDoubleClickScale,
+} from './double-click-zoom'
+
+const VIEWPORT = { canvasWidth: 393, canvasHeight: 852 }
+
+function stagesFor(imageWidth: number, imageHeight: number) {
+  const input = { ...VIEWPORT, imageWidth, imageHeight }
+  return resolveDoubleClickZoomStages({
+    fitScale: computeFitScale(input),
+    fillScale: computeFillScale(input),
+    originalScale: 1,
+  })
+}
+
+it('cycles fit -> fill -> 100% -> fit when the photo is larger than the viewport', () => {
+  const stages = stagesFor(6000, 4000)
+  const [fit, fill, original] = stages
+
+  assert.equal(stages.length, 3)
+  assert.equal(fit, 393 / 6000)
+  assert.equal(fill, 852 / 4000)
+  assert.equal(original, 1)
+
+  assert.equal(resolveNextDoubleClickScale(fit, stages), fill)
+  assert.equal(resolveNextDoubleClickScale(fill, stages), original)
+  assert.equal(resolveNextDoubleClickScale(original, stages), fit)
+})
+
+it('skips the fill stage and goes straight to 100% when the photo is smaller than the viewport', () => {
+  const stages = stagesFor(300, 200)
+
+  assert.deepEqual(stages, [393 / 300, 1])
+  assert.equal(resolveNextDoubleClickScale(stages[0], stages), 1)
+  assert.equal(resolveNextDoubleClickScale(1, stages), stages[0])
+})
+
+it('drops the fill stage when it would upscale beyond 100%, as with a panorama', () => {
+  const stages = stagesFor(8000, 500)
+
+  assert.deepEqual(stages, [393 / 8000, 1])
+})
+
+it('keeps only fit and 100% when the photo aspect ratio matches the viewport', () => {
+  const stages = stagesFor(1179, 2556)
+
+  assert.deepEqual(stages, [393 / 1179, 1])
+})
+
+it('collapses to a single stage when the photo is exactly viewport-sized', () => {
+  const stages = stagesFor(393, 852)
+
+  assert.deepEqual(stages, [1])
+  assert.equal(resolveNextDoubleClickScale(1, stages), 1)
+})
+
+it('after free zooming, advances to the next larger stage or back to fit', () => {
+  const stages = stagesFor(6000, 4000)
+  const [fit, fill] = stages
+
+  assert.equal(resolveNextDoubleClickScale(fill / 2, stages), fill)
+  assert.equal(resolveNextDoubleClickScale(fit / 2, stages), fit)
+  assert.equal(resolveNextDoubleClickScale(2, stages), fit)
+})

--- a/packages/webgl-viewer/src/double-click-zoom.ts
+++ b/packages/webgl-viewer/src/double-click-zoom.ts
@@ -1,0 +1,69 @@
+/**
+ * 双击缩放的分段计算
+ *
+ * 分段顺序（由小到大）：适应屏幕 → 铺满视口 → 100% 原始像素，双击在三段之间循环。
+ * 铺满视口 = 照片有一个维度恰好等于视口、另一个维度 ≥ 视口（cover）。
+ * 只有铺满仍小于 100% 时它才作为中间段保留：照片比视口还小时铺满会超过 100%，
+ * 相当于把照片放大到糊，这种情况直接跳过铺满，双击一次就落到 100%。
+ */
+
+const SCALE_MATCH_EPSILON = 0.01
+
+function isSameScale(a: number, b: number): boolean {
+  return Math.abs(a / b - 1) < SCALE_MATCH_EPSILON
+}
+
+export interface ViewportScaleInput {
+  canvasWidth: number
+  canvasHeight: number
+  imageWidth: number
+  imageHeight: number
+}
+
+export interface DoubleClickZoomScales {
+  /** 适应屏幕：完整显示照片的缩放（contain） */
+  fitScale: number
+  /** 铺满视口：一个维度贴合视口、另一个维度溢出的缩放（cover） */
+  fillScale: number
+  /** 100% 原始像素 */
+  originalScale: number
+}
+
+/** 适应屏幕（contain）：完整显示照片所需的最大缩放 */
+export function computeFitScale({ canvasWidth, canvasHeight, imageWidth, imageHeight }: ViewportScaleInput): number {
+  return Math.min(canvasWidth / imageWidth, canvasHeight / imageHeight)
+}
+
+/** 铺满视口（cover）：一个维度贴合视口、另一个维度溢出的缩放 */
+export function computeFillScale({ canvasWidth, canvasHeight, imageWidth, imageHeight }: ViewportScaleInput): number {
+  return Math.max(canvasWidth / imageWidth, canvasHeight / imageHeight)
+}
+
+/** 双击循环里实际存在的分段，从小到大 */
+export function resolveDoubleClickZoomStages({ fitScale, fillScale, originalScale }: DoubleClickZoomScales): number[] {
+  const stages = [fitScale]
+
+  if (fillScale < originalScale && !isSameScale(fillScale, fitScale)) {
+    stages.push(fillScale)
+  }
+
+  if (!isSameScale(originalScale, stages.at(-1)!)) {
+    stages.push(originalScale)
+  }
+
+  return stages
+}
+
+/**
+ * 双击后应该落到哪一段。
+ * 当前缩放命中某一段时前进到下一段，最后一段回到适应屏幕；
+ * 捏合/滚轮自由缩放之后，放大到比当前大的最近一段，已经超过最后一段则回到适应屏幕。
+ */
+export function resolveNextDoubleClickScale(currentScale: number, stages: number[]): number {
+  const currentIndex = stages.findIndex(scale => isSameScale(currentScale, scale))
+  if (currentIndex !== -1) {
+    return stages[(currentIndex + 1) % stages.length]
+  }
+
+  return stages.find(scale => scale > currentScale * (1 + SCALE_MATCH_EPSILON)) ?? stages[0]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1575,6 +1575,9 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 


### PR DESCRIPTION
## 改动

双击照片的缩放从「适应屏幕 ↔ 1:1」改成三段循环：**适应屏幕 → 铺满视口 → 100% → 回到适应**。原来第一次双击就直接冲到 100%，手机上很难用；现在中间多了一段「铺满」。

| 分段 | 缩放 |
| --- | --- |
| 适应屏幕 | `min(cw/iw, ch/ih)` —— 照片完整可见 |
| 铺满视口 | `max(cw/iw, ch/ih)` —— 一个维度恰好贴合视口，另一个维度溢出 |
| 100% | 原始像素 |

- **铺满会超过 100% 时跳过**：照片比视口小、或全景图那种一个维度比视口小时，铺满等于把照片放大到糊，这时直接跳过，双击一次就落到 100%。
- **照片宽高比和视口一致时也跳过铺满**（截图类），避免第一次双击看起来没反应。
- 捏合/滚轮自由缩放之后再双击：放大到比当前大的最近一段；已经超过 100% 则回到适应屏幕。
- 落点仍以双击位置为锚点。

## 覆盖范围

双击逻辑只在 `ImageViewerEngineBase` 里，所以两个引擎都生效——`WebGLImageViewerEngine` 和新的 `WebGPUImageViewerEngine`（HDR / gain map）都继承它，且都没有覆写双击或缩放路径。分段计算抽到了 `src/double-click-zoom.ts`。

## 验证

- `pnpm --filter @afilmory/webgl-viewer test` → 6/6（三段循环、小图跳过铺满、全景图、宽高比一致、照片恰好等于视口、自由缩放后前进）
- `pnpm --filter @afilmory/webgl-viewer type-check` ✅ · `pnpm --filter web type-check` ✅

## 备注

另外带了两个已在暂存区里的 lint 附带改动：`ContainedImageFrame.tsx` 的 prettier/eslint 格式化，以及 `entry-animation-state.test.ts` 的 `node:test` → `vitest` 迁移（eslint `test/no-import-node-test` 自动修复）。`webgl-viewer` 新增了 `vitest` devDependency 和 `test` 脚本，用来跑新增的测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
