### PR TITLE
fix(site): restore community gallery loading

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      PUBLIC_API_URL: https://api.afilmory.art
+      PUBLIC_API_URL: https://api.afilmory.art/api
       AFILMORY_SITE_STRICT: '1'
       CLOUDFLARE_ACCOUNT_ID: 4d01e7a919eff82eb04333f27cb9da3b
     steps:

--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -6,7 +6,7 @@ Afilmory 官网落地页（Astro + React 岛屿）。
 
 ```bash
 # 在 monorepo 根目录
-export PUBLIC_API_URL=https://api.afilmory.art   # 按现网 API 主机调整
+export PUBLIC_API_URL=https://api.afilmory.art/api   # API 基础地址须包含 /api 前缀
 pnpm site:dev
 ```
 
@@ -19,7 +19,7 @@ pnpm site:dev
 pnpm site:build
 
 # 生产 / CI（缺 PUBLIC_API_URL 直接失败）
-AFILMORY_SITE_STRICT=1 PUBLIC_API_URL=https://api.afilmory.art pnpm site:build
+AFILMORY_SITE_STRICT=1 PUBLIC_API_URL=https://api.afilmory.art/api pnpm site:build
 ```
 
 产物：`apps/site/dist/`


### PR DESCRIPTION
The landing page requests `/gallery-directory` without the backend's `/api` prefix. The deployed endpoint returns HTTP 200 with HTML, so JSON parsing fails and the community gallery shows a loading error.

Set the deployment's `PUBLIC_API_URL` to `https://api.afilmory.art/api` and update the existing development and build examples to match.

Validation:
- Reproduced the deployed error in Chromium and confirmed the incorrect request returned HTML.
- `pnpm site:build` passed with the updated workflow configuration in an isolated workspace using the same lockfile.
- Playwright against the production build and live API loaded 20 gallery cards at desktop (1440 × 1000) and mobile (390 × 844) sizes; Chinese/English switching retained the cards, with no page runtime errors.
- Prettier checks for both changed files and `git diff --check` passed.
