### PR TITLE
fix(web): use exiftool's signed GPSAltitude instead of re-deriving the sign

### DIFF
--- a/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
+++ b/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
@@ -204,8 +204,7 @@ const PhotoMarkerCardContent = ({
             <div className="flex items-center gap-2">
               <i className="i-mingcute-mountain-2-line text-sm" />
               <span className="font-mono">
-                <span>{marker.altitudeRef === 'Below Sea Level' ? '-' : ''}</span>
-                <span>{Math.abs(marker.altitude).toFixed(1)}</span>
+                <span>{marker.altitude.toFixed(1)}</span>
                 <span>m</span>
               </span>
             </div>

--- a/apps/web/src/lib/map-utils.altitude.test.ts
+++ b/apps/web/src/lib/map-utils.altitude.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+
+import type { PickedExif } from '@afilmory/builder'
+import { describe, it } from 'vitest'
+
+import { convertExifGPSToDecimal } from './map-utils'
+
+// GPSAltitude is exiftool's *composite* tag: exiftool has already applied
+// GPSAltitudeRef to the raw value, so the sign on the number is the source of
+// truth. GPSAltitudeRef itself is stored as a number `0 | 1` for entries that
+// went through the v9→v10 manifest migration and as exiftool's original
+// `'Above Sea Level' | 'Below Sea Level'` string for everything ingested since,
+// so it must never be used to re-derive the sign.
+const withGps = (gps: Record<string, unknown>): PickedExif =>
+  ({
+    GPSLatitude: 24.42675,
+    GPSLatitudeRef: 'N',
+    GPSLongitude: 115.16005,
+    GPSLongitudeRef: 'E',
+    ...gps,
+  }) as unknown as PickedExif
+
+describe('convertExifGPSToDecimal altitude sign', () => {
+  it('keeps an above-sea-level photo positive when the reference is a string', () => {
+    const result = convertExifGPSToDecimal(withGps({ GPSAltitude: 47.1, GPSAltitudeRef: 'Above Sea Level' }))
+
+    assert.equal(result?.altitude, 47.1)
+    assert.equal(result?.altitudeRef, 'Above Sea Level')
+  })
+
+  it('keeps an above-sea-level photo positive when the reference is the migrated number', () => {
+    const result = convertExifGPSToDecimal(withGps({ GPSAltitude: 47.1, GPSAltitudeRef: 0 }))
+
+    assert.equal(result?.altitude, 47.1)
+  })
+
+  it('does not re-negate a below-sea-level photo whose value is already signed', () => {
+    const result = convertExifGPSToDecimal(withGps({ GPSAltitude: -0.8933000096, GPSAltitudeRef: 'Below Sea Level' }))
+
+    assert.equal(result?.altitude, -0.8933000096)
+    assert.equal(result?.altitudeRef, 'Below Sea Level')
+  })
+
+  it('does not re-negate a below-sea-level photo with a migrated numeric reference', () => {
+    const result = convertExifGPSToDecimal(withGps({ GPSAltitude: -5.385563266, GPSAltitudeRef: 1 }))
+
+    assert.equal(result?.altitude, -5.385563266)
+  })
+
+  it('treats a missing reference as above sea level without flipping the sign', () => {
+    // Several cameras (e.g. Panasonic) never write GPSAltitudeRef, so exiftool
+    // reports the unsigned magnitude and the direction is unrecoverable.
+    const result = convertExifGPSToDecimal(withGps({ GPSAltitude: 47.1 }))
+
+    assert.equal(result?.altitude, 47.1)
+    assert.equal(result?.altitudeRef, 'Above Sea Level')
+  })
+
+  it('keeps a zero altitude instead of dropping it', () => {
+    const result = convertExifGPSToDecimal(withGps({ GPSAltitude: 0, GPSAltitudeRef: 0 }))
+
+    assert.equal(result?.altitude, 0)
+  })
+})

--- a/apps/web/src/lib/map-utils.ts
+++ b/apps/web/src/lib/map-utils.ts
@@ -57,15 +57,16 @@ export function convertExifGPSToDecimal(exif: PickedExif | null): {
     let altitude: number | undefined
     let altitudeRef: 'Above Sea Level' | 'Below Sea Level' | undefined
 
-    if (exif.GPSAltitude && typeof exif.GPSAltitude === 'number') {
+    if (typeof exif.GPSAltitude === 'number') {
+      // GPSAltitude is exiftool's *composite* tag: it has already applied
+      // GPSAltitudeRef to the raw value, so the sign is authoritative. Derive the
+      // label from the value rather than re-applying the reference — the reference
+      // is stored as a number `0 | 1` for entries that went through the v9→v10
+      // manifest migration and as exiftool's `'Above/Below Sea Level'` string for
+      // everything ingested since, so re-applying it double-negates below-sea-level
+      // photos under either shape.
       altitude = exif.GPSAltitude
-      // 0 (above sea level), 1 (below sea level)
-      altitudeRef = exif.GPSAltitudeRef === 1 ? 'Below Sea Level' : 'Above Sea Level'
-
-      // Apply altitude reference
-      if (altitudeRef === 'Below Sea Level') {
-        altitude = -altitude
-      }
+      altitudeRef = altitude < 0 ? 'Below Sea Level' : 'Above Sea Level'
     }
 
     // Validate coordinates using the validation function

--- a/apps/web/src/modules/metadata/formatExifData.tsx
+++ b/apps/web/src/modules/metadata/formatExifData.tsx
@@ -304,11 +304,12 @@ export const formatExifData = (exif: PickedExif | null) => {
   // 评分
   const rating = exif.Rating
 
-  const GPSAltitudeIsAboveSeaLevel = exif.GPSAltitudeRef === 0
-
   // GPS 信息
+  // GPSAltitude 是 exiftool 的 composite 标签，正负号已经按 GPSAltitudeRef 处理好，
+  // 直接用即可。再从 GPSAltitudeRef 反推符号会让海平面以上的照片全部显示为负值，
+  // 且该字段在不同入库时期分别是数字与字符串，无法用单一比较判断。
   const gpsInfo = {
-    altitude: exif.GPSAltitude ? `${GPSAltitudeIsAboveSeaLevel ? '' : '-'}${exif.GPSAltitude}` : null,
+    altitude: typeof exif.GPSAltitude === 'number' ? String(exif.GPSAltitude) : null,
     latitude: exif.GPSLatitude ? `${exif.GPSLatitude}° ${exif.GPSLatitudeRef}` : null,
     longitude: exif.GPSLongitude ? `${exif.GPSLongitude}° ${exif.GPSLongitudeRef}` : null,
   }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,18 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { defineConfig } from 'vitest/config'
 
+const root = path.dirname(fileURLToPath(import.meta.url))
+
 export default defineConfig({
+  resolve: {
+    // Mirrors the `~/*` path mapping in tsconfig.json so tests can import modules
+    // that use the alias (vitest does not read vite.config.ts when this file exists).
+    alias: {
+      '~': path.resolve(root, 'src'),
+    },
+  },
   test: {
     environment: 'node',
   },

--- a/be/apps/dashboard/src/modules/photos/components/library/PhotoExifDetailsModal.tsx
+++ b/be/apps/dashboard/src/modules/photos/components/library/PhotoExifDetailsModal.tsx
@@ -228,12 +228,16 @@ const convertGPSToDecimal = (
   const latitudeRef = getExifValue<string>(exif, 'GPSLatitudeRef')
   const longitudeRef = getExifValue<string>(exif, 'GPSLongitudeRef')
   const altitudeRaw = getExifValue<number | string>(exif, 'GPSAltitude')
-  const altitudeRef = getExifValue<string>(exif, 'GPSAltitudeRef')
+  // GPSAltitude is exiftool's composite tag and already carries the sign applied
+  // from GPSAltitudeRef, so derive the direction from the value. The reference tag
+  // is stored as a number for entries that went through the v9→v10 manifest
+  // migration and as a string for everything ingested since, so matching it against
+  // one shape mislabels the other (and double-negates below-sea-level entries).
   const altitudeNumber = parseNumber(altitudeRaw)
   const altitudeValue =
     altitudeNumber !== null
-      ? altitudeRef === 'Below Sea Level'
-        ? t(exifKeys.altitude.below, { value: altitudeNumber })
+      ? altitudeNumber < 0
+        ? t(exifKeys.altitude.below, { value: Math.abs(altitudeNumber) })
         : t(exifKeys.altitude.above, { value: altitudeNumber })
       : null
 

--- a/packages/typing/src/photo.ts
+++ b/packages/typing/src/photo.ts
@@ -209,10 +209,19 @@ export interface PickedExif {
   SensingMethod: Tags['SensingMethod']
   FocalPlaneXResolution: Tags['FocalPlaneXResolution']
   FocalPlaneYResolution: Tags['FocalPlaneYResolution']
+  /**
+   * exiftool 的 composite 标签：正负号已按 GPSAltitudeRef 应用，直接使用即可。
+   * 该标签缺失时（部分相机不写入 GPSAltitudeRef）这里是无符号的幅值，方向不可恢复。
+   */
   GPSAltitude: Tags['GPSAltitude']
   GPSLatitude: Tags['GPSLatitude']
   GPSLongitude: Tags['GPSLongitude']
-  GPSAltitudeRef: Tags['GPSAltitudeRef']
+  /**
+   * manifest 中存在两种形态：经 v9→v10 迁移的条目是数字 `0 | 1`，迁移之后新入库的
+   * 照片是 exiftool 的字符串 `'Above Sea Level' | 'Below Sea Level'`。不要用它反推
+   * GPSAltitude 的正负号——符号已经在 GPSAltitude 里了。
+   */
+  GPSAltitudeRef: Tags['GPSAltitudeRef'] | 'Above Sea Level' | 'Below Sea Level'
   GPSLatitudeRef: Tags['GPSLatitudeRef']
   GPSLongitudeRef: Tags['GPSLongitudeRef']
 


### PR DESCRIPTION
Fixes the GPS altitude shown in the EXIF panel, which currently prefixes a minus sign to **every above-sea-level photo**.

## Reproducing on the official demo

[demo.afilmory.art](https://demo.afilmory.art/) — open any photo with GPS data, e.g. `DSCF5200`, and look at 位置信息 → 海拔:

| Photo | Actual altitude | Shown as |
| --- | --- | --- |
| `DSCF5200` | 10 m | **-10m** |
| `DSCF5179` | 9 m | **-9m** |
| `DSCF5178` | 7 m | **-7m** |
| `DSCF4648` | 22 m | **-22m** |

All 4 photos on the demo that carry an altitude are rendered with a wrong sign. This isn't limited to the demo: sampling the 20 galleries in `api.afilmory.art/api/gallery-directory` gives **699 of 984 photos with an altitude rendering incorrectly, across 16 of the 20 galleries**. Where the reference is stored as a string, the figure is 100% wrong (210/210, 99/99, 87/87, …).

## Root cause

The code derives the sign itself instead of using the sign exiftool already applied:

```ts
const GPSAltitudeIsAboveSeaLevel = exif.GPSAltitudeRef === 0
altitude: exif.GPSAltitude ? `${GPSAltitudeIsAboveSeaLevel ? '' : '-'}${exif.GPSAltitude}` : null,
```

`GPSAltitude` is exiftool's **composite** tag. Its `ValueConv` in `Image/ExifTool/GPS.pm` already folds `GPSAltitudeRef` into the value:

```perl
ValueConv => q{
    foreach (0,2) {
        next unless defined $val[$_] and IsFloat($val[$_]) and defined $val[$_+1];
        return $val[$_+1] ? -abs($val[$_]) : $val[$_];   # <- sign applied here
    }
    return undef;
},
```

And `exiftool-vendored` asks for exactly that composite value — `GPSAltitude` is in its `numericTags`, so `-GPSAltitude#` is passed while `GPSAltitudeRef#` is not. Reading the same file both ways confirms it:

```
$ exiftool -json -api struct=1 -G1 -GPSAltitude# -all photo.jpg
"GPS:GPSAltitude":        0.8933000096
"Composite:GPSAltitude": -0.8933000096     <- what the manifest stores
"GPS:GPSAltitudeRef":    "Below Sea Level" <- what the check compares against
```

`GPSAltitudeRef` is therefore a *display* string, while the type the consumers were written against says `number`.

## Why it only shows up on recent photos

`GPSAltitudeRef` exists in two shapes, and the split is a timestamp:

| `GPSAltitudeRef` | Where it comes from | Renders |
| --- | --- | --- |
| `0` / `1` | entries converted by the v9→v10 migration | correct |
| `'Above Sea Level'` / `'Below Sea Level'` | everything ingested since | wrong |

The v9→v10 migration that normalised these to numbers only ever ran once — `migrateManifestFileIfNeeded` is guarded by `manifest.version !== CURRENT_MANIFEST_VERSION`, and manifests are already `v10`, so it never runs again. New photos keep arriving with the string form, so **every new upload with GPS is wrong from the moment it lands**. On a sample gallery the string refs start exactly at the commit that introduced the numeric comparison.

Since `'Above Sea Level' !== 0`, the expression is always `false` and the "below sea level" branch is taken unconditionally — which also double-negates genuinely below-sea-level photos into `--0.8933000096m`.

## Fix

Trust the sign carried by `GPSAltitude` and drop the reference comparisons in all three consumers:

- **`formatExifData`** — use the value as-is.
- **`map-utils`** — derive the `altitudeRef` label from the value's sign. It previously forced `'Above Sea Level'` for everything, since `GPSAltitudeRef === 1` never matched.
- **`PhotoMarkerPin`** — it paired `Math.abs(altitude)` with that always-"Above" label, so below-sea-level markers lost their minus sign. This one failed in the opposite direction.

Also drop the truthiness check on `GPSAltitude` so an altitude of exactly `0` survives, and document the two shapes on `PickedExif.GPSAltitudeRef` so it isn't used as a sign source again. `be/apps/dashboard` had the same assumption and rendered `-3 m (below sea level)`; it now derives direction from the value too.

## Testing

Added `apps/web/src/lib/map-utils.altitude.test.ts`, a vitest regression test covering every combination of value sign × reference shape (numeric `0`, numeric `1`, both strings, and missing). It fails 3/6 against the current code and passes after the fix.

`vitest.config.ts` gained a `~` alias — vitest doesn't read `vite.config.ts` when its own config exists, so tests importing modules that use the tsconfig path mapping couldn't resolve before.

Verified: `pnpm --filter web type-check`, `@afilmory/builder`, `@afilmory/webgl-viewer`, `@afilmory/viewer-motion`, and the dashboard's `tsc --noEmit` all pass. `pnpm type-check` in CI does not run eslint; the pre-existing lint drift on the touched files is unchanged (identical error counts before and after).

## Note on data

This fixes the display for both shapes without touching the manifest, so no rebuild or migration is required. The field itself stays inconsistent, which is worth cleaning up separately — the migration that was meant to normalise it is now inert.
