### PR TITLE
fix(web): 使用 exiftool 已带符号的 GPSAltitude，不再重复推导符号

### DIFF
--- a/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
+++ b/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
@@ -204,8 +204,7 @@ const PhotoMarkerCardContent = ({
             <div className="flex items-center gap-2">
               <i className="i-mingcute-mountain-2-line text-sm" />
               <span className="font-mono">
-                <span>{marker.altitudeRef === 'Below Sea Level' ? '-' : ''}</span>
-                <span>{Math.abs(marker.altitude).toFixed(1)}</span>
+                <span>{marker.altitude.toFixed(1)}</span>
                 <span>m</span>
               </span>
             </div>

--- a/apps/web/src/lib/map-utils.ts
+++ b/apps/web/src/lib/map-utils.ts
@@ -57,15 +57,9 @@ export function convertExifGPSToDecimal(exif: PickedExif | null): {
     let altitude: number | undefined
     let altitudeRef: 'Above Sea Level' | 'Below Sea Level' | undefined
 
-    if (exif.GPSAltitude && typeof exif.GPSAltitude === 'number') {
+    if (typeof exif.GPSAltitude === 'number') {
       altitude = exif.GPSAltitude
-      // 0 (above sea level), 1 (below sea level)
-      altitudeRef = exif.GPSAltitudeRef === 1 ? 'Below Sea Level' : 'Above Sea Level'
-
-      // Apply altitude reference
-      if (altitudeRef === 'Below Sea Level') {
-        altitude = -altitude
-      }
+      altitudeRef = altitude < 0 ? 'Below Sea Level' : 'Above Sea Level'
     }
 
     // Validate coordinates using the validation function

--- a/apps/web/src/modules/metadata/formatExifData.tsx
+++ b/apps/web/src/modules/metadata/formatExifData.tsx
@@ -304,11 +304,9 @@ export const formatExifData = (exif: PickedExif | null) => {
   // 评分
   const rating = exif.Rating
 
-  const GPSAltitudeIsAboveSeaLevel = exif.GPSAltitudeRef === 0
-
   // GPS 信息
   const gpsInfo = {
-    altitude: exif.GPSAltitude ? `${GPSAltitudeIsAboveSeaLevel ? '' : '-'}${exif.GPSAltitude}` : null,
+    altitude: typeof exif.GPSAltitude === 'number' ? String(exif.GPSAltitude) : null,
     latitude: exif.GPSLatitude ? `${exif.GPSLatitude}° ${exif.GPSLatitudeRef}` : null,
     longitude: exif.GPSLongitude ? `${exif.GPSLongitude}° ${exif.GPSLongitudeRef}` : null,
   }

--- a/be/apps/dashboard/src/modules/photos/components/library/PhotoExifDetailsModal.tsx
+++ b/be/apps/dashboard/src/modules/photos/components/library/PhotoExifDetailsModal.tsx
@@ -228,12 +228,11 @@ const convertGPSToDecimal = (
   const latitudeRef = getExifValue<string>(exif, 'GPSLatitudeRef')
   const longitudeRef = getExifValue<string>(exif, 'GPSLongitudeRef')
   const altitudeRaw = getExifValue<number | string>(exif, 'GPSAltitude')
-  const altitudeRef = getExifValue<string>(exif, 'GPSAltitudeRef')
   const altitudeNumber = parseNumber(altitudeRaw)
   const altitudeValue =
     altitudeNumber !== null
-      ? altitudeRef === 'Below Sea Level'
-        ? t(exifKeys.altitude.below, { value: altitudeNumber })
+      ? altitudeNumber < 0
+        ? t(exifKeys.altitude.below, { value: Math.abs(altitudeNumber) })
         : t(exifKeys.altitude.above, { value: altitudeNumber })
       : null
 

--- a/packages/typing/src/photo.ts
+++ b/packages/typing/src/photo.ts
@@ -212,7 +212,7 @@ export interface PickedExif {
   GPSAltitude: Tags['GPSAltitude']
   GPSLatitude: Tags['GPSLatitude']
   GPSLongitude: Tags['GPSLongitude']
-  GPSAltitudeRef: Tags['GPSAltitudeRef']
+  GPSAltitudeRef: Tags['GPSAltitudeRef'] | 'Above Sea Level' | 'Below Sea Level'
   GPSLatitudeRef: Tags['GPSLatitudeRef']
   GPSLongitudeRef: Tags['GPSLongitudeRef']
 


### PR DESCRIPTION
**修复前**，EXIF 面板里**所有海平面以上的照片都会被加上一个负号**。本 PR 修正该符号推导。

## 复现（修复前）

官方 demo：[demo.afilmory.art](https://demo.afilmory.art/) —— 打开任意带 GPS 的照片，看「位置信息 → 海拔」：

| 照片 | 实际海拔 | 修复前显示 |
| --- | --- | --- |
| `DSCF5200` | 10 m | **-10m** |
| `DSCF5179` | 9 m | **-9m** |
| `DSCF5178` | 7 m | **-7m** |
| `DSCF4648` | 22 m | **-22m** |

demo 上带海拔的 4 张照片**全部显示错误**。这不是 demo 个例：从 `api.afilmory.art/api/gallery-directory` 取 20 个公开画廊抽样，**984 张带海拔的照片里有 699 张渲染错误，20 个画廊中 16 个受影响**；在 `GPSAltitudeRef` 以字符串形式存储的画廊里错误率是 100%（210/210、99/99、87/87……）。

## 根因

代码自己算了一遍符号，而 exiftool 已经算过了：

```ts
const GPSAltitudeIsAboveSeaLevel = exif.GPSAltitudeRef === 0
altitude: exif.GPSAltitude ? `${GPSAltitudeIsAboveSeaLevel ? '' : '-'}${exif.GPSAltitude}` : null,
```

`GPSAltitude` 是 exiftool 的 **composite** 标签，它的 `ValueConv` 已经把 `GPSAltitudeRef` 折算进数值了（`Image/ExifTool/GPS.pm`）：

```perl
ValueConv => q{
    foreach (0,2) {
        next unless defined $val[$_] and IsFloat($val[$_]) and defined $val[$_+1];
        return $val[$_+1] ? -abs($val[$_]) : $val[$_];   # <- 符号在这里就应用了
    }
    return undef;
},
```

而 `exiftool-vendored` 要的正是这个 composite 值——`GPSAltitude` 在它的 `numericTags` 里，会传 `-GPSAltitude#`，但 `GPSAltitudeRef#` 不在，所以拿到的是字符串。同一个文件两种读法可以直接对照：

```
$ exiftool -json -api struct=1 -G1 -GPSAltitude# -all photo.jpg
"GPS:GPSAltitude":        0.8933000096
"Composite:GPSAltitude": -0.8933000096     <- manifest 里存的就是这个
"GPS:GPSAltitudeRef":    "Below Sea Level" <- 判断拿它比
```

也就是说 `GPSAltitudeRef` 是个**展示用字符串**，而消费方是照着 `number` 类型写的。

## 为什么只有新照片出错

`GPSAltitudeRef` 存在两种形态，分界线是一个时间点：

| `GPSAltitudeRef` | 来源 | 修复前渲染 |
| --- | --- | --- |
| `0` / `1` | 经 v9→v10 迁移转换过的条目 | 正确 |
| `'Above Sea Level'` / `'Below Sea Level'` | 迁移之后入库的所有照片 | 错误 |

v9→v10 那次归一化只跑过一次——`migrateManifestFileIfNeeded` 的守卫是 `manifest.version !== CURRENT_MANIFEST_VERSION`，而 manifest 现在已经是 `v10`，这个迁移**再也不会执行**。新照片持续以字符串形式入库，所以**每上传一张带 GPS 的新照片就错一张**。样本画廊里字符串 ref 的起点，正好是引入数字比较的那次提交。

因为 `'Above Sea Level' !== 0` 恒成立，表达式永远是 `false`，于是无条件走「海平面以下」分支——这也让真正海平面以下的照片被双重取负，显示成 `--0.8933000096m`。

## 修复

信任 `GPSAltitude` 自带的符号，去掉三处消费方的 reference 比较：

- **`formatExifData`** —— 直接使用该值。
- **`map-utils`** —— 由数值符号推导 `altitudeRef` 标签。它此前对一切都强制 `'Above Sea Level'`，因为 `GPSAltitudeRef === 1` 永不匹配。
- **`PhotoMarkerPin`** —— 它把 `Math.abs(altitude)` 和上面那个恒为「Above」的标签配对，导致海平面以下的标记**丢失**负号，错的方向正好相反。

同时去掉 `GPSAltitude` 的真值判断，让海拔恰好为 `0` 的照片不再被丢弃。`be/apps/dashboard` 有同样的假设，会渲染出 `-3 m (低于海平面)`，也改为由数值推导方向。


## 关于数据

本次改动不触碰 manifest，两种形态都能正确显示，无需重建或迁移。但该字段本身仍然不一致，值得后续单独清理——那个本应用于归一化的迁移目前已经失效。
